### PR TITLE
Implementation of variadic arguments

### DIFF
--- a/src/VM/Core/Runtime/Entity/Array_.php
+++ b/src/VM/Core/Runtime/Entity/Array_.php
@@ -34,7 +34,7 @@ class Array_ extends Entity implements EntityInterface
         return $this;
     }
 
-    public function each(ContextInterface $context): void
+    public function each(ContextInterface $context): RubyClassInterface
     {
         /**
          * @var ArraySymbol $symbol
@@ -50,7 +50,11 @@ class Array_ extends Entity implements EntityInterface
                 previousContext: $context,
             ));
 
-            if (!$symbol[$i] instanceof \RubyVM\VM\Core\YARV\Essential\Symbol\SymbolInterface) {
+            // Renew environment table
+            $executor->context()
+                ->renewEnvironmentTable();
+
+            if (!$symbol[$i] instanceof SymbolInterface) {
                 throw new RuntimeException(
                     sprintf(
                         'Out of index#%d in Array',
@@ -61,8 +65,8 @@ class Array_ extends Entity implements EntityInterface
 
             $object = Number::createBy($symbol[$i]->valueOf())
                 ->toBeRubyClass()
-                ->setRuntimeContext($context)
-                ->setUserlandHeapSpace($context->self()->userlandHeapSpace());
+                ->setRuntimeContext($executor->context())
+                ->setUserlandHeapSpace($executor->context()->self()->userlandHeapSpace());
 
             $executor->context()
                 ->environmentTable()
@@ -81,6 +85,9 @@ class Array_ extends Entity implements EntityInterface
                 throw $result->threw;
             }
         }
+
+        return Nil::createBy()
+            ->toBeRubyClass();
     }
 
     public function push(RubyClassInterface $object): self

--- a/src/VM/Core/Runtime/Entity/Nil.php
+++ b/src/VM/Core/Runtime/Entity/Nil.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace RubyVM\VM\Core\Runtime\Entity;
 
+use RubyVM\VM\Core\Runtime\Essential\RubyClassInterface;
 use RubyVM\VM\Core\YARV\Essential\Symbol\NilSymbol;
 
 class Nil extends Entity implements EntityInterface
@@ -15,6 +16,15 @@ class Nil extends Entity implements EntityInterface
 
     public static function createBy(mixed $value = null): EntityInterface
     {
-        return new self(new NilSymbol());
+        static $symbol = new NilSymbol();
+
+        return new self($symbol);
+    }
+
+    public function toBeRubyClass(): RubyClassInterface
+    {
+        static $class = null;
+
+        return $class ??= parent::toBeRubyClass();
     }
 }

--- a/src/VM/Core/Runtime/Entity/Range.php
+++ b/src/VM/Core/Runtime/Entity/Range.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace RubyVM\VM\Core\Runtime\Entity;
 
 use RubyVM\VM\Core\Helper\ClassHelper;
-use RubyVM\VM\Core\Runtime\Executor\Context\OperationProcessorContext;
+use RubyVM\VM\Core\Runtime\Executor\Context\ContextInterface;
 use RubyVM\VM\Core\Runtime\Executor\Executor;
 use RubyVM\VM\Core\Runtime\Executor\LocalTableHelper;
 use RubyVM\VM\Core\Runtime\Option;
@@ -18,7 +18,7 @@ class Range extends Entity implements EntityInterface
         $this->symbol = $symbol;
     }
 
-    public function each(OperationProcessorContext $context): EntityInterface
+    public function each(ContextInterface $context): EntityInterface
     {
         foreach ($this->symbol->valueOf() as $index => $number) {
             $executor = (new Executor(

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinDefineclass.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinDefineclass.php
@@ -84,8 +84,11 @@ class BuiltinDefineclass implements OperationProcessorInterface
             instructionSequence: $instructionSequence,
             option: $this->context->option(),
             debugger: $this->context->debugger(),
-            previousContext: $this->context->renewEnvironmentTable(),
+            previousContext: $this->context,
         ));
+
+        $executor->context()
+            ->renewEnvironmentTable();
 
         $executor->context()
             ->appendTrace($class->entity()->valueOf());

--- a/src/VM/Core/Runtime/Executor/Operation/Processor/OperationProcessorEntries.php
+++ b/src/VM/Core/Runtime/Executor/Operation/Processor/OperationProcessorEntries.php
@@ -33,4 +33,9 @@ class OperationProcessorEntries extends AbstractEntries
 
         return $processor;
     }
+
+    public function __debugInfo(): array
+    {
+        return [];
+    }
 }

--- a/src/VM/Core/Runtime/Kernel/Ruby3_2/InstructionSequence/ObjectParameterFlags.php
+++ b/src/VM/Core/Runtime/Kernel/Ruby3_2/InstructionSequence/ObjectParameterFlags.php
@@ -22,4 +22,9 @@ class ObjectParameterFlags implements ObjectParameterFlagsInterface
         public readonly bool $acceptsNoKeywordArg,
         public readonly bool $ruby2Keywords,
     ) {}
+
+    public function hasRest(): bool
+    {
+        return $this->hasRest;
+    }
 }

--- a/src/VM/Core/YARV/Criterion/InstructionSequence/ObjectParameterFlagsInterface.php
+++ b/src/VM/Core/YARV/Criterion/InstructionSequence/ObjectParameterFlagsInterface.php
@@ -4,4 +4,7 @@ declare(strict_types=1);
 
 namespace RubyVM\VM\Core\YARV\Criterion\InstructionSequence;
 
-interface ObjectParameterFlagsInterface {}
+interface ObjectParameterFlagsInterface
+{
+    public function hasRest(): bool;
+}

--- a/tests/Version/Ruby3_2/MethodTest.php
+++ b/tests/Version/Ruby3_2/MethodTest.php
@@ -132,4 +132,29 @@ class MethodTest extends TestApplication
         $this->assertSame(ExecutedStatus::SUCCESS, $executor->execute()->executedStatus);
         $this->assertSame("Hello World!\n", $rubyVMManager->stdOut->readAll());
     }
+
+    public function testVariadicArguments(): void
+    {
+        $rubyVMManager = $this->createRubyVMFromCode(
+            <<< '_'
+            def variadic_arguments(a, b, *params)
+              puts a
+              params.each do |param|
+                puts param
+              end
+
+              # Check if VM stack is not empty (call a method testing)
+              puts b
+            end
+            variadic_arguments(1, 5, 2, 3, 4)
+            _,
+        );
+
+        $executor = $rubyVMManager
+            ->rubyVM
+            ->disassemble(RubyVersion::VERSION_3_2);
+
+        $this->assertSame(ExecutedStatus::SUCCESS, $executor->execute()->executedStatus);
+        $this->assertSame("1\n2\n3\n4\n5\n", $rubyVMManager->stdOut->readAll());
+    }
 }


### PR DESCRIPTION
supports variadic syntax

```ruby
def variadic_arguments(a, b, *params)
  puts a
  params.each do |param|
    puts param
  end
  puts b
end

variadic_arguments(1, 2, 3, 4, 5)

```