### PR TITLE
Implementation of keyword arguments

### DIFF
--- a/src/VM/Core/Runtime/Entity/Array_.php
+++ b/src/VM/Core/Runtime/Entity/Array_.php
@@ -47,7 +47,7 @@ class Array_ extends Entity implements EntityInterface
                 instructionSequence: $context->instructionSequence(),
                 option: $context->option(),
                 debugger: $context->debugger(),
-                previousContext: $context,
+                parentContext: $context,
             ));
 
             // Renew environment table

--- a/src/VM/Core/Runtime/Entity/Range.php
+++ b/src/VM/Core/Runtime/Entity/Range.php
@@ -27,7 +27,7 @@ class Range extends Entity implements EntityInterface
                 instructionSequence: $context->instructionSequence(),
                 option: $context->option(),
                 debugger: $context->debugger(),
-                previousContext: $context,
+                parentContext: $context,
             ));
 
             $executor->context()

--- a/src/VM/Core/Runtime/Executor/ArgumentTransformable.php
+++ b/src/VM/Core/Runtime/Executor/ArgumentTransformable.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace RubyVM\VM\Core\Runtime\Executor;
 
 use RubyVM\VM\Core\Runtime\Essential\RubyClassInterface;
-use RubyVM\VM\Core\Runtime\Executor\Context\ContextInterface;
 use RubyVM\VM\Core\Runtime\Executor\Operation\Operand;
 use RubyVM\VM\Core\YARV\Criterion\InstructionSequence\CallInfoInterface;
 use RubyVM\VM\Core\YARV\Essential\ID;

--- a/src/VM/Core/Runtime/Executor/ArgumentTransformable.php
+++ b/src/VM/Core/Runtime/Executor/ArgumentTransformable.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace RubyVM\VM\Core\Runtime\Executor;
 
 use RubyVM\VM\Core\Runtime\Essential\RubyClassInterface;
+use RubyVM\VM\Core\Runtime\Executor\Context\ContextInterface;
 use RubyVM\VM\Core\Runtime\Executor\Operation\Operand;
 use RubyVM\VM\Core\YARV\Criterion\InstructionSequence\CallInfoInterface;
 use RubyVM\VM\Core\YARV\Essential\ID;
@@ -14,7 +15,7 @@ use RubyVM\VM\Core\YARV\Essential\ID;
  * But in other language, especially it based on an object oriented programming languages cannot be flexible.
  * for that reason, this trait class is helping they are problems.
  */
-trait Translatable
+trait ArgumentTransformable
 {
     use Validatable;
 

--- a/src/VM/Core/Runtime/Executor/Context/ContextInterface.php
+++ b/src/VM/Core/Runtime/Executor/Context/ContextInterface.php
@@ -11,6 +11,7 @@ use RubyVM\VM\Core\Runtime\Executor\Debugger\ExecutorDebugger;
 use RubyVM\VM\Core\Runtime\Executor\EnvironmentTable;
 use RubyVM\VM\Core\Runtime\Executor\ExecutorInterface;
 use RubyVM\VM\Core\Runtime\OptionInterface;
+use RubyVM\VM\Core\YARV\Criterion\InstructionSequence\CallInfoInterface;
 use RubyVM\VM\Core\YARV\Criterion\InstructionSequence\InstructionSequenceInterface;
 
 interface ContextInterface
@@ -57,6 +58,8 @@ interface ContextInterface
     public function IOContext(): IOContext;
 
     public function option(): OptionInterface;
+
+    public function parentContext(): ?ContextInterface;
 
     public function modulePath(string $path = null): string;
 }

--- a/src/VM/Core/Runtime/Executor/Context/ContextInterface.php
+++ b/src/VM/Core/Runtime/Executor/Context/ContextInterface.php
@@ -11,7 +11,6 @@ use RubyVM\VM\Core\Runtime\Executor\Debugger\ExecutorDebugger;
 use RubyVM\VM\Core\Runtime\Executor\EnvironmentTable;
 use RubyVM\VM\Core\Runtime\Executor\ExecutorInterface;
 use RubyVM\VM\Core\Runtime\OptionInterface;
-use RubyVM\VM\Core\YARV\Criterion\InstructionSequence\CallInfoInterface;
 use RubyVM\VM\Core\YARV\Criterion\InstructionSequence\InstructionSequenceInterface;
 
 interface ContextInterface

--- a/src/VM/Core/Runtime/Executor/Context/NullContext.php
+++ b/src/VM/Core/Runtime/Executor/Context/NullContext.php
@@ -11,7 +11,9 @@ use RubyVM\VM\Core\Runtime\Executor\Debugger\ExecutorDebugger;
 use RubyVM\VM\Core\Runtime\Executor\EnvironmentTable;
 use RubyVM\VM\Core\Runtime\Executor\ExecutorInterface;
 use RubyVM\VM\Core\Runtime\OptionInterface;
+use RubyVM\VM\Core\YARV\Criterion\InstructionSequence\CallInfoInterface;
 use RubyVM\VM\Core\YARV\Criterion\InstructionSequence\InstructionSequenceInterface;
+use RubyVM\VM\Exception\ContextNotFound;
 use RubyVM\VM\Exception\RuntimeException;
 
 class NullContext implements ContextInterface
@@ -121,6 +123,11 @@ class NullContext implements ContextInterface
         );
     }
 
+    public function parentContext(): ?ContextInterface
+    {
+        return null;
+    }
+
     public function option(): OptionInterface
     {
         return $this->option;
@@ -129,5 +136,15 @@ class NullContext implements ContextInterface
     public function modulePath(string $path = null): string
     {
         return '';
+    }
+
+    public function setCallInfo(CallInfoInterface $callInfo): self
+    {
+        return $this;
+    }
+
+    public function callInfo(): ?CallInfoInterface
+    {
+        return null;
     }
 }

--- a/src/VM/Core/Runtime/Executor/Context/NullContext.php
+++ b/src/VM/Core/Runtime/Executor/Context/NullContext.php
@@ -13,7 +13,6 @@ use RubyVM\VM\Core\Runtime\Executor\ExecutorInterface;
 use RubyVM\VM\Core\Runtime\OptionInterface;
 use RubyVM\VM\Core\YARV\Criterion\InstructionSequence\CallInfoInterface;
 use RubyVM\VM\Core\YARV\Criterion\InstructionSequence\InstructionSequenceInterface;
-use RubyVM\VM\Exception\ContextNotFound;
 use RubyVM\VM\Exception\RuntimeException;
 
 class NullContext implements ContextInterface

--- a/src/VM/Core/Runtime/Executor/Context/OperationProcessorContext.php
+++ b/src/VM/Core/Runtime/Executor/Context/OperationProcessorContext.php
@@ -23,6 +23,7 @@ class OperationProcessorContext implements ContextInterface
      * @param string[] $traces
      */
     public function __construct(
+        private readonly ?ContextInterface $parentContext,
         private readonly KernelInterface $kernel,
         private readonly ExecutorInterface $executor,
         private readonly RubyClassInterface $rubyClass,
@@ -72,6 +73,7 @@ class OperationProcessorContext implements ContextInterface
     public function createSnapshot(): self
     {
         return new self(
+            parentContext: $this->parentContext,
             kernel: clone $this->kernel,
             executor: clone $this->executor,
             rubyClass: clone $this->rubyClass,
@@ -168,6 +170,11 @@ class OperationProcessorContext implements ContextInterface
     public function IOContext(): IOContext
     {
         return $this->IOContext;
+    }
+
+    public function parentContext(): ?ContextInterface
+    {
+        return $this->parentContext;
     }
 
     public function modulePath(string $path = null): string

--- a/src/VM/Core/Runtime/Executor/Debugger/BreakpointExecutable.php
+++ b/src/VM/Core/Runtime/Executor/Debugger/BreakpointExecutable.php
@@ -21,7 +21,7 @@ trait BreakpointExecutable
         return $this;
     }
 
-    private function processBreakPoint(Insn $insn, ContextInterface $previousContext, ContextInterface $nextContext): void
+    private function processBreakPoint(Insn $insn, ContextInterface $parentContext, ContextInterface $nextContext): void
     {
         printf('Enter to next step (y/n/q): ');
         $entered = fread(STDIN, 1024);
@@ -41,12 +41,12 @@ trait BreakpointExecutable
             );
             printf(
                 "Previous Stacks: %s#%d\n",
-                (string) $previousContext->vmStack(),
-                spl_object_id($previousContext->vmStack()),
+                (string) $parentContext->vmStack(),
+                spl_object_id($parentContext->vmStack()),
             );
             printf(
                 "Previous Local Tables: %s\n",
-                (string) $previousContext->environmentTable(),
+                (string) $parentContext->environmentTable(),
             );
             printf(
                 "Current Stacks: %s#%d\n",

--- a/src/VM/Core/Runtime/Executor/Executor.php
+++ b/src/VM/Core/Runtime/Executor/Executor.php
@@ -43,9 +43,9 @@ class Executor implements ExecutorInterface
         private readonly InstructionSequenceInterface $instructionSequence,
         private readonly OptionInterface $option,
         private readonly ExecutorDebugger $debugger = new ExecutorDebugger(),
-        private readonly ?ContextInterface $previousContext = null,
+        private readonly ?ContextInterface $parentContext = null,
     ) {
-        $this->context = $this->createContext($this->previousContext);
+        $this->context = $this->createContext($this->parentContext);
     }
 
     public function context(): ContextInterface
@@ -84,30 +84,31 @@ class Executor implements ExecutorInterface
         return $executor;
     }
 
-    public function createContext(?ContextInterface $previousContext = null): ContextInterface
+    public function createContext(?ContextInterface $parentContext = null): ContextInterface
     {
         return new OperationProcessorContext(
+            $parentContext,
             $this->kernel,
             $this,
             $this->rubyClass,
-            $previousContext?->vmStack() ?? new VMStack(),
+            $parentContext?->vmStack() ?? new VMStack(),
             new ProgramCounter(),
             $this->instructionSequence,
             $this->option,
-            $previousContext?->IOContext() ?? new IOContext(
+            $parentContext?->IOContext() ?? new IOContext(
                 $this->option->stdOut(),
                 $this->option->stdOut(),
                 $this->option->stdOut(),
             ),
-            $previousContext?->environmentTable() ?? new EnvironmentTable(),
+            $parentContext?->environmentTable() ?? new EnvironmentTable(),
             $this->debugger,
-            $previousContext instanceof \RubyVM\VM\Core\Runtime\Executor\Context\ContextInterface
-                ? $previousContext->depth() + 1
+            $parentContext instanceof \RubyVM\VM\Core\Runtime\Executor\Context\ContextInterface
+                ? $parentContext->depth() + 1
                 : 0,
-            $previousContext?->startTime() ?? null,
-            $this->shouldProcessedRecords ?? $previousContext?->shouldProcessedRecords() ?? false,
-            $this->shouldBreakPoint ?? $previousContext?->shouldBreakPoint() ?? false,
-            $previousContext?->traces() ?? [],
+            $parentContext?->startTime() ?? null,
+            $this->shouldProcessedRecords ?? $parentContext?->shouldProcessedRecords() ?? false,
+            $this->shouldBreakPoint ?? $parentContext?->shouldBreakPoint() ?? false,
+            $parentContext?->traces() ?? [],
         );
     }
 

--- a/src/VM/Core/Runtime/Executor/ExecutorInterface.php
+++ b/src/VM/Core/Runtime/Executor/ExecutorInterface.php
@@ -21,5 +21,5 @@ interface ExecutorInterface
 
     public function context(): ContextInterface;
 
-    public function createContext(?ContextInterface $previousContext = null): ContextInterface;
+    public function createContext(?ContextInterface $parentContext = null): ContextInterface;
 }

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinDefineclass.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinDefineclass.php
@@ -84,7 +84,7 @@ class BuiltinDefineclass implements OperationProcessorInterface
             instructionSequence: $instructionSequence,
             option: $this->context->option(),
             debugger: $this->context->debugger(),
-            previousContext: $this->context,
+            parentContext: $this->context,
         ));
 
         $executor->context()

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinDefinemethod.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinDefinemethod.php
@@ -79,7 +79,7 @@ class BuiltinDefinemethod implements OperationProcessorInterface
             instructionSequence: $instructionSequence,
             option: $this->context->option(),
             debugger: $this->context->debugger(),
-            previousContext: $context,
+            parentContext: $context,
         );
 
         $receiverClass

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinInvokeblock.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinInvokeblock.php
@@ -13,12 +13,12 @@ use RubyVM\VM\Core\Runtime\Executor\Operation\Operand;
 use RubyVM\VM\Core\Runtime\Executor\Operation\OperandHelper;
 use RubyVM\VM\Core\Runtime\Executor\Operation\Processor\OperationProcessorInterface;
 use RubyVM\VM\Core\Runtime\Executor\ProcessedStatus;
-use RubyVM\VM\Core\Runtime\Executor\Translatable;
+use RubyVM\VM\Core\Runtime\Executor\ArgumentTransformable;
 use RubyVM\VM\Exception\OperationProcessorException;
 
 class BuiltinInvokeblock implements OperationProcessorInterface
 {
-    use Translatable;
+    use ArgumentTransformable;
     use OperandHelper;
     use CallBlockHelper;
 

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinOptSendWithoutBlock.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinOptSendWithoutBlock.php
@@ -15,7 +15,7 @@ use RubyVM\VM\Core\Runtime\Executor\Operation\Processor\OperationProcessorInterf
 use RubyVM\VM\Core\Runtime\Executor\Operation\SpecialMethodCallerEntries;
 use RubyVM\VM\Core\Runtime\Executor\ProcessedStatus;
 use RubyVM\VM\Core\Runtime\Executor\SpecialMethod\SpecialMethodInterface;
-use RubyVM\VM\Core\Runtime\Executor\Translatable;
+use RubyVM\VM\Core\Runtime\Executor\ArgumentTransformable;
 use RubyVM\VM\Core\Runtime\Executor\Validatable;
 use RubyVM\VM\Core\YARV\Essential\Symbol\StringSymbol;
 use RubyVM\VM\Exception\OperationProcessorException;
@@ -24,7 +24,7 @@ class BuiltinOptSendWithoutBlock implements OperationProcessorInterface
 {
     use OperandHelper;
     use Validatable;
-    use Translatable;
+    use ArgumentTransformable;
 
     private Insn $insn;
 
@@ -79,6 +79,13 @@ class BuiltinOptSendWithoutBlock implements OperationProcessorInterface
         }
 
         $targetClass->setRuntimeContext($this->context);
+
+        // Set current call info into instruction sequence
+        $this->context
+            ->instructionSequence()
+            ->body()
+            ->info()
+            ->setCurrentCallInfo($callInfo);
 
         $result = null;
 

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinSend.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinSend.php
@@ -59,8 +59,9 @@ class BuiltinSend implements OperationProcessorInterface
             $blockIseqNumber,
             $blockObject,
             false,
-            ...$this->translateForArguments(
 
+            // @phpstan-ignore-next-line
+            ...$this->translateForArguments(
                 ...$arguments,
             ),
         );

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinSend.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinSend.php
@@ -12,14 +12,14 @@ use RubyVM\VM\Core\Runtime\Executor\Operation\Operand;
 use RubyVM\VM\Core\Runtime\Executor\Operation\OperandHelper;
 use RubyVM\VM\Core\Runtime\Executor\Operation\Processor\OperationProcessorInterface;
 use RubyVM\VM\Core\Runtime\Executor\ProcessedStatus;
-use RubyVM\VM\Core\Runtime\Executor\Translatable;
+use RubyVM\VM\Core\Runtime\Executor\ArgumentTransformable;
 use RubyVM\VM\Core\Runtime\Executor\Validatable;
 
 class BuiltinSend implements OperationProcessorInterface
 {
     use OperandHelper;
     use Validatable;
-    use Translatable;
+    use ArgumentTransformable;
     use CallBlockHelper;
 
     private Insn $insn;
@@ -59,7 +59,10 @@ class BuiltinSend implements OperationProcessorInterface
             $blockIseqNumber,
             $blockObject,
             false,
-            ...$this->translateForArguments(...$arguments),
+            ...$this->translateForArguments(
+
+                ...$arguments,
+            ),
         );
 
         if ($result instanceof RubyClassInterface) {

--- a/src/VM/Core/Runtime/Kernel/Ruby3_2/InstructionSequence/InstructionSequenceInfo.php
+++ b/src/VM/Core/Runtime/Kernel/Ruby3_2/InstructionSequence/InstructionSequenceInfo.php
@@ -21,36 +21,36 @@ use RubyVM\VM\Exception\RubyVMException;
 class InstructionSequenceInfo implements InstructionSequenceInfoInterface
 {
     protected InstructionSequenceCompileData $compileData;
+
     protected ?CallInfoInterface $currentCallInfo = null;
 
     public function __construct(
-        public readonly int                           $type,
-        public readonly int                           $stackMax,
-        public readonly int                           $iseqSize,
-        public readonly ObjectParameterInterface      $objectParam,
-        public readonly int                           $localTableSize,
-        public readonly int                           $ciSize,
-        public readonly InsnsInterface                $insns,
-        public readonly VariableInterface             $variable,
-        public readonly LocationInterface             $location,
-        public readonly int                           $catchExceptP,
-        public readonly int                           $builtinInlineP,
-        public readonly int                           $ivcSize,
-        public readonly int                           $icvArcSize,
-        public readonly int                           $iseSize,
-        public readonly int                           $icSize,
-        public readonly OuterVariableEntries          $outerVariables,
-        public readonly VariableEntries               $variableEntries,
-        public readonly CatchEntries                  $catchTable,
+        public readonly int $type,
+        public readonly int $stackMax,
+        public readonly int $iseqSize,
+        public readonly ObjectParameterInterface $objectParam,
+        public readonly int $localTableSize,
+        public readonly int $ciSize,
+        public readonly InsnsInterface $insns,
+        public readonly VariableInterface $variable,
+        public readonly LocationInterface $location,
+        public readonly int $catchExceptP,
+        public readonly int $builtinInlineP,
+        public readonly int $ivcSize,
+        public readonly int $icvArcSize,
+        public readonly int $iseSize,
+        public readonly int $icSize,
+        public readonly OuterVariableEntries $outerVariables,
+        public readonly VariableEntries $variableEntries,
+        public readonly CatchEntries $catchTable,
         public readonly ?InstructionSequenceInterface $parentISeq,
         public readonly ?InstructionSequenceInterface $localISeq,
         public readonly ?InstructionSequenceInterface $mandatoryOnlyISeq,
-        public readonly CallInfoEntries               $callInfoEntries,
-        public readonly int                           $bytecodeOffset,
-        public readonly int                           $bytecodeSize,
-        private ?OperationEntries                     $operationEntries = null,
-    )
-    {
+        public readonly CallInfoEntries $callInfoEntries,
+        public readonly int $bytecodeOffset,
+        public readonly int $bytecodeSize,
+        private ?OperationEntries $operationEntries = null,
+    ) {
         $this->compileData = new InstructionSequenceCompileData();
     }
 
@@ -119,6 +119,7 @@ class InstructionSequenceInfo implements InstructionSequenceInfoInterface
     public function setCurrentCallInfo(CallInfoInterface $callInfo): self
     {
         $this->currentCallInfo = $callInfo;
+
         return $this;
     }
 }

--- a/src/VM/Core/Runtime/Kernel/Ruby3_2/InstructionSequence/InstructionSequenceInfo.php
+++ b/src/VM/Core/Runtime/Kernel/Ruby3_2/InstructionSequence/InstructionSequenceInfo.php
@@ -9,6 +9,7 @@ use RubyVM\VM\Core\YARV\Criterion\Entry\CallInfoEntries;
 use RubyVM\VM\Core\YARV\Criterion\Entry\CatchEntries;
 use RubyVM\VM\Core\YARV\Criterion\Entry\OuterVariableEntries;
 use RubyVM\VM\Core\YARV\Criterion\Entry\VariableEntries;
+use RubyVM\VM\Core\YARV\Criterion\InstructionSequence\CallInfoInterface;
 use RubyVM\VM\Core\YARV\Criterion\InstructionSequence\InsnsInterface;
 use RubyVM\VM\Core\YARV\Criterion\InstructionSequence\InstructionSequenceInfoInterface;
 use RubyVM\VM\Core\YARV\Criterion\InstructionSequence\InstructionSequenceInterface;
@@ -20,34 +21,36 @@ use RubyVM\VM\Exception\RubyVMException;
 class InstructionSequenceInfo implements InstructionSequenceInfoInterface
 {
     protected InstructionSequenceCompileData $compileData;
+    protected ?CallInfoInterface $currentCallInfo = null;
 
     public function __construct(
-        public readonly int $type,
-        public readonly int $stackMax,
-        public readonly int $iseqSize,
-        public readonly ObjectParameterInterface $objectParam,
-        public readonly int $localTableSize,
-        public readonly int $ciSize,
-        public readonly InsnsInterface $insns,
-        public readonly VariableInterface $variable,
-        public readonly LocationInterface $location,
-        public readonly int $catchExceptP,
-        public readonly int $builtinInlineP,
-        public readonly int $ivcSize,
-        public readonly int $icvArcSize,
-        public readonly int $iseSize,
-        public readonly int $icSize,
-        public readonly OuterVariableEntries $outerVariables,
-        public readonly VariableEntries $localTable,
-        public readonly CatchEntries $catchTable,
+        public readonly int                           $type,
+        public readonly int                           $stackMax,
+        public readonly int                           $iseqSize,
+        public readonly ObjectParameterInterface      $objectParam,
+        public readonly int                           $localTableSize,
+        public readonly int                           $ciSize,
+        public readonly InsnsInterface                $insns,
+        public readonly VariableInterface             $variable,
+        public readonly LocationInterface             $location,
+        public readonly int                           $catchExceptP,
+        public readonly int                           $builtinInlineP,
+        public readonly int                           $ivcSize,
+        public readonly int                           $icvArcSize,
+        public readonly int                           $iseSize,
+        public readonly int                           $icSize,
+        public readonly OuterVariableEntries          $outerVariables,
+        public readonly VariableEntries               $variableEntries,
+        public readonly CatchEntries                  $catchTable,
         public readonly ?InstructionSequenceInterface $parentISeq,
         public readonly ?InstructionSequenceInterface $localISeq,
         public readonly ?InstructionSequenceInterface $mandatoryOnlyISeq,
-        public readonly CallInfoEntries $callInfoEntries,
-        public readonly int $bytecodeOffset,
-        public readonly int $bytecodeSize,
-        private ?OperationEntries $operationEntries = null,
-    ) {
+        public readonly CallInfoEntries               $callInfoEntries,
+        public readonly int                           $bytecodeOffset,
+        public readonly int                           $bytecodeSize,
+        private ?OperationEntries                     $operationEntries = null,
+    )
+    {
         $this->compileData = new InstructionSequenceCompileData();
     }
 
@@ -96,5 +99,26 @@ class InstructionSequenceInfo implements InstructionSequenceInfoInterface
     public function objectParam(): ObjectParameterInterface
     {
         return $this->objectParam;
+    }
+
+    public function variables(): VariableEntries
+    {
+        return $this->variableEntries;
+    }
+
+    public function callInfoEntries(): CallInfoEntries
+    {
+        return $this->callInfoEntries;
+    }
+
+    public function currentCallInfo(): ?CallInfoInterface
+    {
+        return $this->currentCallInfo;
+    }
+
+    public function setCurrentCallInfo(CallInfoInterface $callInfo): self
+    {
+        $this->currentCallInfo = $callInfo;
+        return $this;
     }
 }

--- a/src/VM/Core/Runtime/Kernel/Ruby3_2/InstructionSequence/InstructionSequenceProcessor.php
+++ b/src/VM/Core/Runtime/Kernel/Ruby3_2/InstructionSequence/InstructionSequenceProcessor.php
@@ -230,7 +230,7 @@ class InstructionSequenceProcessor implements InstructionSequenceProcessorInterf
             iseSize: $iseSize,
             icSize: $icSize,
             outerVariables: $outerVariables,
-            localTable: $localTable,
+            variableEntries: $localTable,
             catchTable: $catchTable,
             parentISeq: $parentISeq,
             localISeq: $localISeq,

--- a/src/VM/Core/Runtime/Kernel/Ruby3_2/InstructionSequence/InstructionSequenceProcessor.php
+++ b/src/VM/Core/Runtime/Kernel/Ruby3_2/InstructionSequence/InstructionSequenceProcessor.php
@@ -455,7 +455,12 @@ class InstructionSequenceProcessor implements InstructionSequenceProcessorInterf
         $reader->pos($localTableOffset);
 
         for ($i = 0; $i < $localTableSize; ++$i) {
+            // NOTE: only to read 4 bytes
             $entries[] = new VariableEntry($this->kernel->findId($reader->readAsUnsignedLong()));
+
+            // TODO: You must using longlong but the PHP cannot read longlong value
+            // You will rewrite here to enable to read by longlong
+            $reader->readAsUnsignedLong();
         }
 
         return $entries;

--- a/src/VM/Core/Runtime/Lambda.php
+++ b/src/VM/Core/Runtime/Lambda.php
@@ -39,7 +39,7 @@ class Lambda implements MainInterface
             instructionSequence: $this->instructionSequence,
             option: $this->context()->option(),
             debugger: $this->context()->debugger(),
-            previousContext: $this->context(),
+            parentContext: $this->context(),
         );
 
         $localTableSize = $this

--- a/src/VM/Core/YARV/Criterion/Entry/CallData.php
+++ b/src/VM/Core/YARV/Criterion/Entry/CallData.php
@@ -35,4 +35,9 @@ class CallData implements CallDataInterface
     {
         return $this->argc;
     }
+
+    public function keywords(): ?array
+    {
+        return $this->keywords;
+    }
 }

--- a/src/VM/Core/YARV/Criterion/Entry/CallData.php
+++ b/src/VM/Core/YARV/Criterion/Entry/CallData.php
@@ -36,6 +36,9 @@ class CallData implements CallDataInterface
         return $this->argc;
     }
 
+    /**
+     * @return null|StringSymbol[]
+     */
     public function keywords(): ?array
     {
         return $this->keywords;

--- a/src/VM/Core/YARV/Criterion/InstructionSequence/CallDataInterface.php
+++ b/src/VM/Core/YARV/Criterion/InstructionSequence/CallDataInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace RubyVM\VM\Core\YARV\Criterion\InstructionSequence;
 
 use RubyVM\VM\Core\YARV\Essential\ID;
+use RubyVM\VM\Core\YARV\Essential\Symbol\StringSymbol;
 
 interface CallDataInterface
 {
@@ -14,5 +15,8 @@ interface CallDataInterface
 
     public function argumentsCount(): int;
 
+    /**
+     * @return null|StringSymbol[]
+     */
     public function keywords(): ?array;
 }

--- a/src/VM/Core/YARV/Criterion/InstructionSequence/CallDataInterface.php
+++ b/src/VM/Core/YARV/Criterion/InstructionSequence/CallDataInterface.php
@@ -13,4 +13,6 @@ interface CallDataInterface
     public function mid(): ID;
 
     public function argumentsCount(): int;
+
+    public function keywords(): ?array;
 }

--- a/src/VM/Core/YARV/Criterion/InstructionSequence/InstructionSequenceInfoInterface.php
+++ b/src/VM/Core/YARV/Criterion/InstructionSequence/InstructionSequenceInfoInterface.php
@@ -17,6 +17,7 @@ interface InstructionSequenceInfoInterface
     public function inlineCacheSize(): int;
 
     public function localTableSize(): int;
+
     public function variables(): VariableEntries;
 
     public function compileData(): InstructionSequenceCompileDataInterface;

--- a/src/VM/Core/YARV/Criterion/InstructionSequence/InstructionSequenceInfoInterface.php
+++ b/src/VM/Core/YARV/Criterion/InstructionSequence/InstructionSequenceInfoInterface.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace RubyVM\VM\Core\YARV\Criterion\InstructionSequence;
 
 use RubyVM\VM\Core\Runtime\Executor\Operation\OperationEntries;
+use RubyVM\VM\Core\YARV\Criterion\Entry\CallInfoEntries;
+use RubyVM\VM\Core\YARV\Criterion\Entry\VariableEntries;
 
 interface InstructionSequenceInfoInterface
 {
@@ -15,6 +17,7 @@ interface InstructionSequenceInfoInterface
     public function inlineCacheSize(): int;
 
     public function localTableSize(): int;
+    public function variables(): VariableEntries;
 
     public function compileData(): InstructionSequenceCompileDataInterface;
 
@@ -25,4 +28,10 @@ interface InstructionSequenceInfoInterface
     public function setOperationEntries(OperationEntries $entries): InstructionSequenceInfoInterface;
 
     public function operationEntries(): OperationEntries;
+
+    public function callInfoEntries(): CallInfoEntries;
+
+    public function currentCallInfo(): ?CallInfoInterface;
+
+    public function setCurrentCallInfo(CallInfoInterface $callInfo): self;
 }

--- a/tests/Version/Ruby3_2/MethodTest.php
+++ b/tests/Version/Ruby3_2/MethodTest.php
@@ -157,4 +157,26 @@ class MethodTest extends TestApplication
         $this->assertSame(ExecutedStatus::SUCCESS, $executor->execute()->executedStatus);
         $this->assertSame("1\n2\n3\n4\n5\n", $rubyVMManager->stdOut->readAll());
     }
+
+    public function testKeywordArguments(): void
+    {
+        $rubyVMManager = $this->createRubyVMFromCode(
+            <<< '_'
+            def name(a:, b:, c:)
+              puts a
+              puts b
+              puts c
+            end
+            name(c: "neko", a: "tanuki", b: "inu")
+
+            _,
+        );
+
+        $executor = $rubyVMManager
+            ->rubyVM
+            ->disassemble(RubyVersion::VERSION_3_2);
+
+        $this->assertSame(ExecutedStatus::SUCCESS, $executor->execute()->executedStatus);
+        $this->assertSame("tanuki\ninu\nneko\n", $rubyVMManager->stdOut->readAll());
+    }
 }


### PR DESCRIPTION
Supports

```ruby
def name(a:, b:, c:)
  puts a
  puts b
  puts c
end

name(c: "neko", a: "tanuki", b: "inu")
```