### PR TITLE
Fix callinfo cannot call on instantiated class

### DIFF
--- a/src/VM/Core/Runtime/Entity/Array_.php
+++ b/src/VM/Core/Runtime/Entity/Array_.php
@@ -9,6 +9,7 @@ use RubyVM\VM\Core\Runtime\Essential\RubyClassInterface;
 use RubyVM\VM\Core\Runtime\Executor\Context\ContextInterface;
 use RubyVM\VM\Core\Runtime\Executor\Executor;
 use RubyVM\VM\Core\Runtime\Option;
+use RubyVM\VM\Core\YARV\Criterion\InstructionSequence\CallInfoInterface;
 use RubyVM\VM\Core\YARV\Essential\Symbol\ArraySymbol;
 use RubyVM\VM\Core\YARV\Essential\Symbol\SymbolInterface;
 use RubyVM\VM\Exception\RuntimeException;
@@ -34,7 +35,7 @@ class Array_ extends Entity implements EntityInterface
         return $this;
     }
 
-    public function each(ContextInterface $context): RubyClassInterface
+    public function each(CallInfoInterface $callInfo, ContextInterface $context): RubyClassInterface
     {
         /**
          * @var ArraySymbol $symbol
@@ -90,7 +91,7 @@ class Array_ extends Entity implements EntityInterface
             ->toBeRubyClass();
     }
 
-    public function push(RubyClassInterface $object): self
+    public function push(CallInfoInterface $callInfo, RubyClassInterface $object): self
     {
         // @phpstan-ignore-next-line
         $this->symbol[] = $object->entity()->symbol();

--- a/src/VM/Core/Runtime/Entity/Number.php
+++ b/src/VM/Core/Runtime/Entity/Number.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace RubyVM\VM\Core\Runtime\Entity;
 
-use RubyVM\VM\Core\Runtime\RubyClass;
+use RubyVM\VM\Core\Runtime\Essential\RubyClassInterface;
+use RubyVM\VM\Core\YARV\Criterion\InstructionSequence\CallInfoInterface;
 use RubyVM\VM\Core\YARV\Essential\Symbol\NumberSymbol;
 
 class Number extends Entity implements EntityInterface
@@ -19,31 +20,31 @@ class Number extends Entity implements EntityInterface
         return (bool) $this->symbol->valueOf();
     }
 
-    public function xor(RubyClass $object): Number
+    public function xor(CallInfoInterface $callInfo, RubyClassInterface $object): Number
     {
         return Number::createBy(
-            $this->symbol->valueOf() ^ $object->entity->symbol()->valueOf(),
+            $this->symbol->valueOf() ^ $object->entity()->symbol()->valueOf(),
         );
     }
 
-    public function power(RubyClass $object): Number
+    public function power(CallInfoInterface $callInfo, RubyClassInterface $object): Number
     {
         return Number::createBy(
-            $this->symbol->valueOf() ** $object->entity->symbol()->valueOf(),
+            $this->symbol->valueOf() ** $object->entity()->symbol()->valueOf(),
         );
     }
 
-    public function rightShift(RubyClass $object): Number
+    public function rightShift(CallInfoInterface $callInfo, RubyClassInterface $object): Number
     {
         return Number::createBy(
-            $this->symbol->valueOf() >> $object->entity->symbol()->valueOf(),
+            $this->symbol->valueOf() >> $object->entity()->symbol()->valueOf(),
         );
     }
 
-    public function compareStrictEquals(RubyClass $object): Boolean_
+    public function compareStrictEquals(CallInfoInterface $callInfo, RubyClassInterface $object): Boolean_
     {
         return Boolean_::createBy(
-            $this->symbol->valueOf() === $object->entity->symbol()->valueOf(),
+            $this->symbol->valueOf() === $object->entity()->symbol()->valueOf(),
         );
     }
 

--- a/src/VM/Core/Runtime/Entity/Range.php
+++ b/src/VM/Core/Runtime/Entity/Range.php
@@ -9,6 +9,7 @@ use RubyVM\VM\Core\Runtime\Executor\Context\ContextInterface;
 use RubyVM\VM\Core\Runtime\Executor\Executor;
 use RubyVM\VM\Core\Runtime\Executor\LocalTableHelper;
 use RubyVM\VM\Core\Runtime\Option;
+use RubyVM\VM\Core\YARV\Criterion\InstructionSequence\CallInfoInterface;
 use RubyVM\VM\Core\YARV\Essential\Symbol\RangeSymbol;
 
 class Range extends Entity implements EntityInterface
@@ -18,7 +19,7 @@ class Range extends Entity implements EntityInterface
         $this->symbol = $symbol;
     }
 
-    public function each(ContextInterface $context): EntityInterface
+    public function each(CallInfoInterface $callInfo, ContextInterface $context): EntityInterface
     {
         foreach ($this->symbol->valueOf() as $index => $number) {
             $executor = (new Executor(

--- a/src/VM/Core/Runtime/Essential/RubyClassImplementationInterface.php
+++ b/src/VM/Core/Runtime/Essential/RubyClassImplementationInterface.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace RubyVM\VM\Core\Runtime\Essential;
 
+use RubyVM\VM\Core\YARV\Criterion\InstructionSequence\CallInfoInterface;
+
 interface RubyClassImplementationInterface
 {
-    public function puts(RubyClassInterface $object): RubyClassInterface;
+    public function puts(CallInfoInterface $callInfo, RubyClassInterface $object): RubyClassInterface;
 
-    public function exit(int $code = 0): void;
+    public function exit(CallInfoInterface $callInfo, int $code = 0): never;
 }

--- a/src/VM/Core/Runtime/Executor/Accessor/BridgeCallData.php
+++ b/src/VM/Core/Runtime/Executor/Accessor/BridgeCallData.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RubyVM\VM\Core\Runtime\Executor\Accessor;
+
+use RubyVM\VM\Core\Runtime\Essential\RubyClassInterface;
+use RubyVM\VM\Core\YARV\Criterion\InstructionSequence\CallDataInterface;
+use RubyVM\VM\Core\YARV\Essential\ID;
+use RubyVM\VM\Core\YARV\Essential\Symbol\StringSymbol;
+
+class BridgeCallData implements CallDataInterface
+{
+    /**
+     * @param RubyClassInterface[] $arguments
+     */
+    public function __construct(private readonly string $name, private readonly array $arguments) {}
+
+    public function flag(): int
+    {
+        // Always public
+        return 0;
+    }
+
+    public function mid(): ID
+    {
+        return new ID(new StringSymbol($this->name));
+    }
+
+    public function argumentsCount(): int
+    {
+        return count($this->arguments);
+    }
+
+    public function keywords(): ?array
+    {
+        // TODO: we must implement accepting keywords arguments on PHP
+        return null;
+    }
+}

--- a/src/VM/Core/Runtime/Executor/Accessor/BridgeCallInfo.php
+++ b/src/VM/Core/Runtime/Executor/Accessor/BridgeCallInfo.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RubyVM\VM\Core\Runtime\Executor\Accessor;
+
+use RubyVM\VM\Core\Runtime\Essential\RubyClassInterface;
+use RubyVM\VM\Core\YARV\Criterion\InstructionSequence\CallDataInterface;
+use RubyVM\VM\Core\YARV\Criterion\InstructionSequence\CallInfoInterface;
+
+class BridgeCallInfo implements CallInfoInterface
+{
+    /**
+     * @param RubyClassInterface[] $arguments
+     */
+    public function __construct(private readonly string $name, private readonly array $arguments) {}
+
+    public function callData(): CallDataInterface
+    {
+        return new BridgeCallData(
+            $this->name,
+            $this->arguments,
+        );
+    }
+}

--- a/src/VM/Core/Runtime/Executor/Accessor/ContextAccessor.php
+++ b/src/VM/Core/Runtime/Executor/Accessor/ContextAccessor.php
@@ -18,14 +18,20 @@ readonly class ContextAccessor implements ContextAccessorInterface
     {
         $self = $this->executedResult->executor->context()->self();
 
+        $arguments = array_map(
+            static fn ($value) => Translator::PHPToRuby($value),
+            $arguments,
+        );
+
         /**
          * @var ExecutedResult $executedResult
          */
         $executedResult = $self->{$name}(
-            ...array_map(
-                static fn ($value) => Translator::PHPToRuby($value),
+            new BridgeCallInfo(
+                $name,
                 $arguments,
             ),
+        ...$arguments,
         );
         if ($executedResult->threw instanceof \Throwable) {
             throw $executedResult->threw;

--- a/src/VM/Core/Runtime/Executor/CallBlockHelper.php
+++ b/src/VM/Core/Runtime/Executor/CallBlockHelper.php
@@ -19,7 +19,7 @@ use RubyVM\VM\Exception\OperationProcessorException;
 
 trait CallBlockHelper
 {
-    private function callSimpleMethod(ContextInterface $context, RubyClassInterface|ContextInterface ...$arguments): ExecutedResult
+    private function callSimpleMethod(ContextInterface $context, CallInfoInterface $callInfo, RubyClassInterface|ContextInterface ...$arguments): ExecutedResult
     {
         // Validate first value is context?
         $calleeContexts = [];
@@ -45,13 +45,6 @@ trait CallBlockHelper
             ->body()
             ->info();
 
-        $currentCallInfo = $context
-            ->parentContext()
-            ?->instructionSequence()
-            ->body()
-            ->info()
-            ->currentCallInfo();
-
         $localTableSize = $iseqBodyData
             ->localTableSize();
 
@@ -71,14 +64,14 @@ trait CallBlockHelper
             $startOfSplat = count($arguments) - $restStart;
 
             $arguments = self::alignArguments(
-                $currentCallInfo,
+                $callInfo,
                 $executor->context(),
                 array_reverse(array_slice($arguments, 0, $startOfSplat)),
                 ...array_slice($arguments, $startOfSplat),
             );
         } else {
             $arguments = self::alignArguments(
-                $currentCallInfo,
+                $callInfo,
                 $executor->context(),
                 ...$arguments,
             );
@@ -152,6 +145,7 @@ trait CallBlockHelper
             ->setRuntimeContext($executor->context())
             ->setUserlandHeapSpace($executor->context()->self()->userlandHeapSpace())
             ->{(string) $callInfo->callData()->mid()->object}(
+                $callInfo,
                 $executor->context(),
                 ...self::alignArguments(
                     $callInfo,

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinInvokeblock.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinInvokeblock.php
@@ -62,6 +62,7 @@ class BuiltinInvokeblock implements OperationProcessorInterface
         $executed = $this
             ->callSimpleMethod(
                 $processorContext,
+                $operand,
                 ...$arguments,
             );
 

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinOptSendWithoutBlock.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinOptSendWithoutBlock.php
@@ -80,13 +80,6 @@ class BuiltinOptSendWithoutBlock implements OperationProcessorInterface
 
         $targetClass->setRuntimeContext($this->context);
 
-        // Set current call info into instruction sequence
-        $this->context
-            ->instructionSequence()
-            ->body()
-            ->info()
-            ->setCurrentCallInfo($callInfo);
-
         $result = null;
 
         // Here is a special method calls
@@ -101,6 +94,7 @@ class BuiltinOptSendWithoutBlock implements OperationProcessorInterface
             $result = $calleeSpecialMethodName->process(
                 $targetClass,
                 $this->context,
+                $callInfo,
                 ...$this->translateForArguments(...$arguments),
             );
         } else {
@@ -108,7 +102,10 @@ class BuiltinOptSendWithoutBlock implements OperationProcessorInterface
              * @var null|ExecutedResult|RubyClassInterface $result
              */
             $result = $targetClass
-                ->{(string) $symbol}(...$this->translateForArguments(...$arguments));
+                ->{(string) $symbol}(
+                    $callInfo,
+                    ...$this->translateForArguments(...$arguments),
+                );
         }
 
         if ($result instanceof RubyClassInterface) {

--- a/src/VM/Core/Runtime/Executor/SpecialMethod/Initialize.php
+++ b/src/VM/Core/Runtime/Executor/SpecialMethod/Initialize.php
@@ -7,10 +7,11 @@ namespace RubyVM\VM\Core\Runtime\Executor\SpecialMethod;
 use RubyVM\VM\Core\Runtime\Essential\RubyClassInterface;
 use RubyVM\VM\Core\Runtime\Executor\Context\ContextInterface;
 use RubyVM\VM\Core\Runtime\Executor\Operation\Operand;
+use RubyVM\VM\Core\YARV\Criterion\InstructionSequence\CallInfoInterface;
 
 class Initialize implements SpecialMethodInterface
 {
-    public function process(RubyClassInterface $class, ContextInterface $context, mixed ...$arguments): mixed
+    public function process(RubyClassInterface $class, ContextInterface $context, CallInfoInterface $callInfo, mixed ...$arguments): mixed
     {
         $result = $class;
 

--- a/src/VM/Core/Runtime/Executor/SpecialMethod/SpecialMethodInterface.php
+++ b/src/VM/Core/Runtime/Executor/SpecialMethod/SpecialMethodInterface.php
@@ -6,8 +6,9 @@ namespace RubyVM\VM\Core\Runtime\Executor\SpecialMethod;
 
 use RubyVM\VM\Core\Runtime\Essential\RubyClassInterface;
 use RubyVM\VM\Core\Runtime\Executor\Context\ContextInterface;
+use RubyVM\VM\Core\YARV\Criterion\InstructionSequence\CallInfoInterface;
 
 interface SpecialMethodInterface
 {
-    public function process(RubyClassInterface $class, ContextInterface $context, mixed ...$arguments): mixed;
+    public function process(RubyClassInterface $class, ContextInterface $context, CallInfoInterface $callInfo, mixed ...$arguments): mixed;
 }

--- a/src/VM/Core/Runtime/Lambda.php
+++ b/src/VM/Core/Runtime/Lambda.php
@@ -9,6 +9,7 @@ use RubyVM\VM\Core\Runtime\Entity\EntityInterface;
 use RubyVM\VM\Core\Runtime\Essential\MainInterface;
 use RubyVM\VM\Core\Runtime\Essential\RubyClassInterface;
 use RubyVM\VM\Core\Runtime\Executor\Executor;
+use RubyVM\VM\Core\YARV\Criterion\InstructionSequence\CallInfoInterface;
 use RubyVM\VM\Core\YARV\Criterion\InstructionSequence\InstructionSequenceInterface;
 use RubyVM\VM\Core\YARV\Criterion\ShouldBeRubyClass;
 use RubyVM\VM\Core\YARV\Essential\Symbol\StringSymbol;
@@ -31,7 +32,7 @@ class Lambda implements MainInterface
         return 'lambda';
     }
 
-    public function call(RubyClassInterface ...$arguments): RubyClassInterface|null
+    public function call(CallInfoInterface $callInfo, RubyClassInterface ...$arguments): RubyClassInterface|null
     {
         $executor = new Executor(
             kernel: $this->context()->kernel(),

--- a/src/VM/Core/Runtime/Provider/ProvideBasicClassMethods.php
+++ b/src/VM/Core/Runtime/Provider/ProvideBasicClassMethods.php
@@ -10,6 +10,7 @@ use RubyVM\VM\Core\Runtime\Essential\RubyClassInterface;
 use RubyVM\VM\Core\Runtime\Executor\Context\ContextInterface;
 use RubyVM\VM\Core\Runtime\Lambda;
 use RubyVM\VM\Core\Runtime\UserlandHeapSpace;
+use RubyVM\VM\Core\YARV\Criterion\InstructionSequence\CallInfoInterface;
 use RubyVM\VM\Core\YARV\Essential\Symbol\ArraySymbol;
 use RubyVM\VM\Core\YARV\Essential\Symbol\NilSymbol;
 use RubyVM\VM\Core\YARV\Essential\Symbol\RangeSymbol;
@@ -17,7 +18,7 @@ use RubyVM\VM\Core\YARV\Essential\Symbol\StringSymbol;
 
 trait ProvideBasicClassMethods
 {
-    public function puts(RubyClassInterface $object): RubyClassInterface
+    public function puts(CallInfoInterface $callInfo, RubyClassInterface $object): RubyClassInterface
     {
         $symbol = $object->entity()->symbol();
 
@@ -44,7 +45,7 @@ trait ProvideBasicClassMethods
             ->toBeRubyClass();
     }
 
-    public function exit(int $code = 0): never
+    public function exit(CallInfoInterface $callInfo, int $code = 0): never
     {
         exit($code);
     }
@@ -60,7 +61,7 @@ trait ProvideBasicClassMethods
             ->toBeRubyClass();
     }
 
-    public function lambda(ContextInterface $context): RubyClassInterface
+    public function lambda(CallInfoInterface $callInfo, ContextInterface $context): RubyClassInterface
     {
         return (new Lambda($context->instructionSequence()))
             ->setRuntimeContext($this->context())

--- a/src/VM/Core/Runtime/Provider/ProvideExtendedMethodCall.php
+++ b/src/VM/Core/Runtime/Provider/ProvideExtendedMethodCall.php
@@ -10,8 +10,10 @@ use RubyVM\VM\Core\Runtime\Executor\CallBlockHelper;
 use RubyVM\VM\Core\Runtime\Executor\Context\ContextInterface;
 use RubyVM\VM\Core\Runtime\Executor\ExecutedResult;
 use RubyVM\VM\Core\Runtime\RubyClass;
+use RubyVM\VM\Core\YARV\Criterion\InstructionSequence\CallInfoInterface;
 use RubyVM\VM\Exception\NotFoundInstanceMethod;
 use RubyVM\VM\Exception\OperationProcessorException;
+use RubyVM\VM\Exception\RuntimeException;
 
 trait ProvideExtendedMethodCall
 {
@@ -52,10 +54,17 @@ trait ProvideExtendedMethodCall
             return $this->__call($context, $arguments);
         }
 
+        if (($arguments[0] ?? null) !== null && !$arguments[0] instanceof CallInfoInterface) {
+            throw new RuntimeException('A CallInfo entry was not passed');
+        }
+
         return $this
             ->callSimpleMethod(
                 $context,
-                ...$arguments,
+
+                // @phpstan-ignore-next-line
+                $arguments[0],
+                ...array_slice($arguments, 1),
             );
     }
 

--- a/tests/Version/Ruby3_2/ClassTest.php
+++ b/tests/Version/Ruby3_2/ClassTest.php
@@ -179,4 +179,64 @@ class ClassTest extends TestApplication
 
         _, $rubyVMManager->stdOut->readAll());
     }
+
+    public function testDynamicMethodItsCallingAsKeywordsArguments(): void
+    {
+        $rubyVMManager = $this->createRubyVMFromCode(
+            <<< '_'
+            class Animal
+              def name(a:, b:, c:)
+                puts a
+                puts b
+                puts c
+              end
+            end
+
+            Animal.new.name(c: "neko", a: "tanuki", b: "inu")
+
+            _,
+        );
+
+        $executor = $rubyVMManager
+            ->rubyVM
+            ->disassemble(RubyVersion::VERSION_3_2);
+
+        $this->assertSame(ExecutedStatus::SUCCESS, $executor->execute()->executedStatus);
+        $this->assertSame(<<< '_'
+        tanuki
+        inu
+        neko
+
+        _, $rubyVMManager->stdOut->readAll());
+    }
+
+    public function testStaticMethodItsCallingAsKeywordsArguments(): void
+    {
+        $rubyVMManager = $this->createRubyVMFromCode(
+            <<< '_'
+            class Animal
+              class << self
+                  def name(a:, b:, c:)
+                    puts a
+                    puts b
+                    puts c
+                  end
+              end
+            end
+            Animal.name(c: "neko", a: "tanuki", b: "inu")
+            _,
+        );
+
+        $executor = $rubyVMManager
+            ->rubyVM
+            ->disassemble(RubyVersion::VERSION_3_2);
+
+        $this->assertSame(ExecutedStatus::SUCCESS, $executor->execute()->executedStatus);
+        $this->assertSame(<<< '_'
+        tanuki
+        inu
+        neko
+
+        _, $rubyVMManager->stdOut->readAll());
+    }
 }


### PR DESCRIPTION
supports

```ruby
class Animal
  class << self
      def name(a:, b:, c:)
        puts a
        puts b
        puts c
      end
  end
end
Animal.name(c: "neko", a: "tanuki", b: "inu")
```

and

```ruby
class Animal
  def name(a:, b:, c:)
    puts a
    puts b
    puts c
  end
end

Animal.new.name(c: "neko", a: "tanuki", b: "inu")
```