### PR TITLE
Implements jump op

### DIFF
--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinJump.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinJump.php
@@ -31,6 +31,12 @@ class BuiltinJump implements OperationProcessorInterface
 
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
-        throw new OperationProcessorException(sprintf('The `%s` (opcode: 0x%02x) processor is not implemented yet', strtolower($this->insn->name), $this->insn->value));
+        $operand = $this->getOperandAsOffset();
+
+        $this->context
+            ->programCounter()
+            ->increase($operand->valueOf());
+
+        return ProcessedStatus::SUCCESS;
     }
 }

--- a/tests/Version/Ruby3_2/SyntaxTest.php
+++ b/tests/Version/Ruby3_2/SyntaxTest.php
@@ -755,4 +755,36 @@ class SyntaxTest extends TestApplication
 
         _, $rubyVMManager->stdOut->readAll());
     }
+
+    public function testContinuingRegExp(): void
+    {
+        $rubyVMManager = $this->createRubyVMFromCode(
+            <<< '_'
+            str = "This is Regexp"
+            if /is Regexp/ =~ str
+              puts "matched!"
+            else
+              puts "unmatched!"
+            end
+
+            if /was Regexp/ =~ str
+              puts "matched!"
+            else
+              puts "unmatched!"
+            end
+
+            _,
+        );
+
+        $executor = $rubyVMManager
+            ->rubyVM
+            ->disassemble(RubyVersion::VERSION_3_2);
+
+        $this->assertSame(ExecutedStatus::SUCCESS, $executor->execute()->executedStatus);
+        $this->assertSame(<<<'_'
+        matched!
+        unmatched!
+
+        _, $rubyVMManager->stdOut->readAll());
+    }
 }


### PR DESCRIPTION
Supports continuously branches

```ruby
str = "This is Regexp"
if /is Regexp/ =~ str
  puts "matched!"
else
  puts "unmatched!"
end

if /was Regexp/ =~ str
  puts "matched!"
else
  puts "unmatched!"
end

```