### PR TITLE
Support nested catch

### DIFF
--- a/src/VM/Core/Runtime/BasicObject/Kernel/Object_/Exception.php
+++ b/src/VM/Core/Runtime/BasicObject/Kernel/Object_/Exception.php
@@ -44,4 +44,9 @@ abstract class Exception extends Object_ implements RubyClassInterface
             ->symbol()
             ->valueOf();
     }
+
+    public function message(): RubyClassInterface
+    {
+        return $this->message;
+    }
 }

--- a/src/VM/Core/Runtime/BasicObject/Kernel/Object_/Exception/StandardError/SystemCallError.php
+++ b/src/VM/Core/Runtime/BasicObject/Kernel/Object_/Exception/StandardError/SystemCallError.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RubyVM\VM\Core\Runtime\BasicObject\Kernel\Object_\Exception\StandardError;
+
+use RubyVM\VM\Core\Runtime\Attribute\BindAliasAs;
+use RubyVM\VM\Core\Runtime\BasicObject\Kernel\Object_\Exception\StandardError;
+use RubyVM\VM\Core\Runtime\Essential\RubyClassifiable;
+use RubyVM\VM\Core\Runtime\Essential\RubyClassInterface;
+
+#[BindAliasAs('SystemCallError')]
+class SystemCallError extends StandardError implements RubyClassInterface, RubyClassifiable {
+
+    #[BindAliasAs('to_s')]
+    public function __toString(): string
+    {
+        return 'unknown error - ' . parent::__toString();
+    }
+}

--- a/src/VM/Core/Runtime/BasicObject/Kernel/Object_/Exception/StandardError/SystemCallError.php
+++ b/src/VM/Core/Runtime/BasicObject/Kernel/Object_/Exception/StandardError/SystemCallError.php
@@ -10,8 +10,8 @@ use RubyVM\VM\Core\Runtime\Essential\RubyClassifiable;
 use RubyVM\VM\Core\Runtime\Essential\RubyClassInterface;
 
 #[BindAliasAs('SystemCallError')]
-class SystemCallError extends StandardError implements RubyClassInterface, RubyClassifiable {
-
+class SystemCallError extends StandardError implements RubyClassInterface, RubyClassifiable
+{
     #[BindAliasAs('to_s')]
     public function __toString(): string
     {

--- a/src/VM/Core/Runtime/Executor/Insn/Insn.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Insn.php
@@ -423,6 +423,7 @@ enum Insn: int
             Insn::GETINSTANCEVARIABLE,
             Insn::SEND => 2,
             Insn::DEFINECLASS => 3,
+            Insn::SETLOCAL, Insn::GETLOCAL => 2,
             default => 1,
         };
     }

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinSetlocal.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinSetlocal.php
@@ -11,8 +11,6 @@ use RubyVM\VM\Core\Runtime\Executor\LocalTable;
 use RubyVM\VM\Core\Runtime\Executor\Operation\OperandHelper;
 use RubyVM\VM\Core\Runtime\Executor\Operation\Processor\OperationProcessorInterface;
 use RubyVM\VM\Core\Runtime\Executor\ProcessedStatus;
-use RubyVM\VM\Core\Runtime\Option;
-use RubyVM\VM\Exception\OperationProcessorException;
 
 class BuiltinSetlocal implements OperationProcessorInterface
 {

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinSetlocal.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinSetlocal.php
@@ -11,6 +11,7 @@ use RubyVM\VM\Core\Runtime\Executor\LocalTable;
 use RubyVM\VM\Core\Runtime\Executor\Operation\OperandHelper;
 use RubyVM\VM\Core\Runtime\Executor\Operation\Processor\OperationProcessorInterface;
 use RubyVM\VM\Core\Runtime\Executor\ProcessedStatus;
+use RubyVM\VM\Core\Runtime\Option;
 use RubyVM\VM\Exception\OperationProcessorException;
 
 class BuiltinSetlocal implements OperationProcessorInterface
@@ -33,6 +34,10 @@ class BuiltinSetlocal implements OperationProcessorInterface
 
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
-        throw new OperationProcessorException(sprintf('The `%s` (opcode: 0x%02x) processor is not implemented yet', strtolower($this->insn->name), $this->insn->value));
+        $slotIndex = $this->getOperandAsNumber()->valueOf();
+        $level = $this->getOperandAsNumber()->valueOf();
+        $this->setLocalTableFromStack($slotIndex, $level);
+
+        return ProcessedStatus::SUCCESS;
     }
 }

--- a/src/VM/Core/Runtime/Provider/ProvideBasicClassMethods.php
+++ b/src/VM/Core/Runtime/Provider/ProvideBasicClassMethods.php
@@ -19,7 +19,6 @@ use RubyVM\VM\Core\YARV\Essential\Symbol\ArraySymbol;
 use RubyVM\VM\Core\YARV\Essential\Symbol\NilSymbol;
 use RubyVM\VM\Core\YARV\Essential\Symbol\RangeSymbol;
 use RubyVM\VM\Core\YARV\Essential\Symbol\StringSymbol;
-use RubyVM\VM\Core\YARV\Essential\Symbol\SymbolSymbol;
 use RubyVM\VM\Exception\Raise;
 
 trait ProvideBasicClassMethods
@@ -93,6 +92,7 @@ trait ProvideBasicClassMethods
         foreach ($this->context()->instructionSequence()->body()->info()->catchEntries() as $entry) {
             if ($pos >= $entry->start() && $entry->end() > $pos) {
                 $lookedUpCatchEntry = $entry;
+
                 break;
             }
         }

--- a/src/VM/Core/Runtime/Provider/ProvideBasicClassMethods.php
+++ b/src/VM/Core/Runtime/Provider/ProvideBasicClassMethods.php
@@ -92,32 +92,8 @@ trait ProvideBasicClassMethods
          */
         foreach ($this->context()->instructionSequence()->body()->info()->catchEntries() as $entry) {
             if ($pos >= $entry->start() && $entry->end() > $pos) {
-                /**
-                 * @var Nil|SymbolSymbol[] $targetClasses
-                 */
-                $targetClasses = $this
-                    ->context()
-                    ->kernel()
-                    ->findObject($entry->cont());
-
-                if ($targetClasses instanceof Nil) {
-                    return Nil::createBy()
-                        ->toBeRubyClass();
-                }
-
-                foreach ($targetClasses as $targetClass) {
-                    if ($targetClass->valueOf() === $class->entity()->valueOf()) {
-                        $lookedUpCatchEntry = $entry;
-                    }
-
-                    if ($lookedUpCatchEntry !== null) {
-                        break;
-                    }
-                }
-
-                if ($lookedUpCatchEntry !== null) {
-                    break;
-                }
+                $lookedUpCatchEntry = $entry;
+                break;
             }
         }
 


### PR DESCRIPTION
supports:

```ruby
begin
  raise RuntimeError, 'Hello World! I am calling via raise expression'
rescue RuntimeError => e
  begin
    raise SystemCallError, e.message + " - Additional message"
  rescue SystemCallError => e
    puts e
  end
end

```