### PR TITLE
Implementation of case and when

### DIFF
--- a/src/VM/Core/Runtime/BasicObject/Kernel/Object_/Regexp.php
+++ b/src/VM/Core/Runtime/BasicObject/Kernel/Object_/Regexp.php
@@ -11,20 +11,20 @@ use RubyVM\VM\Core\Runtime\BasicObject\Symbolizable;
 use RubyVM\VM\Core\Runtime\BasicObject\Symbolize;
 use RubyVM\VM\Core\Runtime\Essential\RubyClassInterface;
 use RubyVM\VM\Core\YARV\Criterion\InstructionSequence\CallInfoInterface;
-use RubyVM\VM\Core\YARV\Essential\Symbol\RegExpSymbol;
+use RubyVM\VM\Core\YARV\Essential\Symbol\RegexpSymbol;
 
 class Regexp extends Object_ implements RubyClassInterface, Symbolize
 {
     use Symbolizable;
 
-    public function __construct(RegExpSymbol $symbol)
+    public function __construct(RegexpSymbol $symbol)
     {
         $this->symbol = $symbol;
     }
 
     public static function createBy(mixed $value = null, int $option = null): self
     {
-        return new self(new RegExpSymbol($value, $option));
+        return new self(new RegexpSymbol($value, $option));
     }
 
     public function __toString(): string

--- a/src/VM/Core/Runtime/ClassCreator.php
+++ b/src/VM/Core/Runtime/ClassCreator.php
@@ -28,7 +28,7 @@ use RubyVM\VM\Core\YARV\Essential\Symbol\NilSymbol;
 use RubyVM\VM\Core\YARV\Essential\Symbol\NumberSymbol;
 use RubyVM\VM\Core\YARV\Essential\Symbol\OffsetSymbol;
 use RubyVM\VM\Core\YARV\Essential\Symbol\RangeSymbol;
-use RubyVM\VM\Core\YARV\Essential\Symbol\RegExpSymbol;
+use RubyVM\VM\Core\YARV\Essential\Symbol\RegexpSymbol;
 use RubyVM\VM\Core\YARV\Essential\Symbol\StringSymbol;
 use RubyVM\VM\Core\YARV\Essential\Symbol\SymbolInterface;
 use RubyVM\VM\Core\YARV\Essential\Symbol\SymbolSymbol;
@@ -55,7 +55,7 @@ class ClassCreator
             UndefinedSymbol::class => new Undefined($symbol),
             VoidSymbol::class => new Void_($symbol),
             SymbolSymbol::class => new Symbol($symbol),
-            RegExpSymbol::class => new Regexp($symbol),
+            RegexpSymbol::class => new Regexp($symbol),
             default => throw new EntityException(
                 sprintf(
                     'The specified entity was not implemented yet: %s',

--- a/src/VM/Core/Runtime/Executor/Insn/Insn.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Insn.php
@@ -424,6 +424,7 @@ enum Insn: int
             Insn::SEND => 2,
             Insn::DEFINECLASS => 3,
             Insn::SETLOCAL, Insn::GETLOCAL => 2,
+            Insn::OPT_CASE_DISPATCH => 2,
             default => 1,
         };
     }

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinOptCaseDispatch.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinOptCaseDispatch.php
@@ -10,7 +10,6 @@ use RubyVM\VM\Core\Runtime\Executor\Insn\Insn;
 use RubyVM\VM\Core\Runtime\Executor\Operation\OperandHelper;
 use RubyVM\VM\Core\Runtime\Executor\Operation\Processor\OperationProcessorInterface;
 use RubyVM\VM\Core\Runtime\Executor\ProcessedStatus;
-use RubyVM\VM\Exception\OperationProcessorException;
 
 class BuiltinOptCaseDispatch implements OperationProcessorInterface
 {
@@ -31,6 +30,16 @@ class BuiltinOptCaseDispatch implements OperationProcessorInterface
 
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
-        throw new OperationProcessorException(sprintf('The `%s` (opcode: 0x%02x) processor is not implemented yet', strtolower($this->insn->name), $this->insn->value));
+        $hash = $this->getOperandAsID();
+        $elseOffset = $this->getOperandAsRubyClass();
+        $key = $this->getStackAsRubyClass();
+
+        if ($key->valueOf() !== $hash->object->valueOf()) {
+            $this->context
+                ->programCounter()
+                ->set($elseOffset->valueOf());
+        }
+
+        return ProcessedStatus::SUCCESS;
     }
 }

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinTopn.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinTopn.php
@@ -10,7 +10,6 @@ use RubyVM\VM\Core\Runtime\Executor\Insn\Insn;
 use RubyVM\VM\Core\Runtime\Executor\Operation\OperandHelper;
 use RubyVM\VM\Core\Runtime\Executor\Operation\Processor\OperationProcessorInterface;
 use RubyVM\VM\Core\Runtime\Executor\ProcessedStatus;
-use RubyVM\VM\Exception\OperationProcessorException;
 
 class BuiltinTopn implements OperationProcessorInterface
 {
@@ -31,6 +30,27 @@ class BuiltinTopn implements OperationProcessorInterface
 
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
-        throw new OperationProcessorException(sprintf('The `%s` (opcode: 0x%02x) processor is not implemented yet', strtolower($this->insn->name), $this->insn->value));
+        $n = $this->getOperandAsNumber();
+        $stacks = [];
+
+        // Get to specified value
+        for ($i = 0; $i <= $n->valueOf(); ++$i) {
+            $stacks[] = $this->getStack();
+        }
+
+        // Re-push same value
+        $this->context->vmStack()->push(
+            $first = array_pop($stacks),
+        );
+
+        // Re-push already existed stacks
+        foreach ($stacks as $stack) {
+            $this->context->vmStack()->push($stack);
+        }
+
+        // New push the specified pos in stacks
+        $this->context->vmStack()->push($first);
+
+        return ProcessedStatus::SUCCESS;
     }
 }

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinTopn.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinTopn.php
@@ -10,6 +10,7 @@ use RubyVM\VM\Core\Runtime\Executor\Insn\Insn;
 use RubyVM\VM\Core\Runtime\Executor\Operation\OperandHelper;
 use RubyVM\VM\Core\Runtime\Executor\Operation\Processor\OperationProcessorInterface;
 use RubyVM\VM\Core\Runtime\Executor\ProcessedStatus;
+use RubyVM\VM\Exception\OperationProcessorException;
 
 class BuiltinTopn implements OperationProcessorInterface
 {
@@ -40,7 +41,9 @@ class BuiltinTopn implements OperationProcessorInterface
 
         // Re-push same value
         $this->context->vmStack()->push(
-            $first = array_pop($stacks),
+            $first = array_pop($stacks) ?? throw new OperationProcessorException(
+                'VMStack is null',
+            ),
         );
 
         // Re-push already existed stacks

--- a/src/VM/Core/Runtime/Kernel/Ruby3_2/InstructionSequence/InstructionSequenceProcessor.php
+++ b/src/VM/Core/Runtime/Kernel/Ruby3_2/InstructionSequence/InstructionSequenceProcessor.php
@@ -326,6 +326,12 @@ class InstructionSequenceProcessor implements InstructionSequenceProcessorInterf
                             ),
                         ),
 
+                        InsnType::TS_CDHASH => new Operand(
+                            $this->kernel->findId(
+                                $reader->smallValue(),
+                            ),
+                        ),
+
                         // Not implemented yet
                         InsnType::TS_VARIABLE,
                         InsnType::TS_IVC,
@@ -333,7 +339,6 @@ class InstructionSequenceProcessor implements InstructionSequenceProcessorInterf
                         InsnType::TS_ISEQ,
                         InsnType::TS_FUNCPTR,
                         InsnType::TS_BUILTIN,
-                        InsnType::TS_CDHASH,
                         InsnType::TS_ICVARC => throw new ExecutorExeption(sprintf('The OperandType#%s is not supported', $operandType->name)),
                     },
                 );

--- a/src/VM/Core/Runtime/Kernel/Ruby3_2/Kernel.php
+++ b/src/VM/Core/Runtime/Kernel/Ruby3_2/Kernel.php
@@ -10,10 +10,11 @@ use RubyVM\VM\Core\Runtime\Kernel\Ruby3_2\HeapSpace\DefaultInstanceHeapSpace;
 use RubyVM\VM\Core\Runtime\Kernel\Ruby3_2\InstructionSequence\InstructionSequenceProcessor;
 use RubyVM\VM\Core\Runtime\Kernel\Ruby3_2\Loader\ArraySymbolLoader;
 use RubyVM\VM\Core\Runtime\Kernel\Ruby3_2\Loader\BooleanSymbolLoader;
+use RubyVM\VM\Core\Runtime\Kernel\Ruby3_2\Loader\CaseDispatchSymbolLoader;
 use RubyVM\VM\Core\Runtime\Kernel\Ruby3_2\Loader\FixedNumberSymbolLoader;
 use RubyVM\VM\Core\Runtime\Kernel\Ruby3_2\Loader\FloatSymbolLoader;
 use RubyVM\VM\Core\Runtime\Kernel\Ruby3_2\Loader\NilSymbolLoader;
-use RubyVM\VM\Core\Runtime\Kernel\Ruby3_2\Loader\RegExpSymbolLoader;
+use RubyVM\VM\Core\Runtime\Kernel\Ruby3_2\Loader\RegexpSymbolLoader;
 use RubyVM\VM\Core\Runtime\Kernel\Ruby3_2\Loader\StringSymbolLoader;
 use RubyVM\VM\Core\Runtime\Kernel\Ruby3_2\Loader\StructSymbolLoader;
 use RubyVM\VM\Core\Runtime\Kernel\Ruby3_2\Loader\SymbolSymbolLoader;
@@ -274,7 +275,8 @@ class Kernel implements KernelInterface
             SymbolType::SYMBOL => new SymbolSymbolLoader($this, $offset),
             SymbolType::STRING => new StringSymbolLoader($this, $offset),
             SymbolType::ARRAY => new ArraySymbolLoader($this, $offset),
-            SymbolType::REGEXP => new RegExpSymbolLoader($this, $offset),
+            SymbolType::REGEXP => new RegexpSymbolLoader($this, $offset),
+            SymbolType::HASH => new CaseDispatchSymbolLoader($this, $offset),
             default => throw new ResolverException("Cannot resolve a symbol: {$info->type->name} - maybe the symbol type is not supported yet"),
         };
     }

--- a/src/VM/Core/Runtime/Kernel/Ruby3_2/Loader/CaseDispatchSymbolLoader.php
+++ b/src/VM/Core/Runtime/Kernel/Ruby3_2/Loader/CaseDispatchSymbolLoader.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RubyVM\VM\Core\Runtime\Kernel\Ruby3_2\Loader;
+
+use RubyVM\VM\Core\Runtime\Essential\KernelInterface;
+use RubyVM\VM\Core\YARV\Criterion\Offset\Offset;
+use RubyVM\VM\Core\YARV\Essential\Symbol\CaseDispatchSymbol;
+use RubyVM\VM\Core\YARV\Essential\Symbol\SymbolInterface;
+use RubyVM\VM\Core\YARV\Essential\Symbol\SymbolLoaderInterface;
+
+class CaseDispatchSymbolLoader implements SymbolLoaderInterface
+{
+    public function __construct(
+        protected readonly KernelInterface $kernel,
+        protected readonly Offset $offset,
+    ) {}
+
+    public function load(): SymbolInterface
+    {
+        $reader = $this->kernel->stream()->duplication();
+        $reader->pos($this->offset->offset);
+
+        $hash = $reader->smallValue();
+        $pos = $reader->smallValue();
+        $len = $reader->smallValue();
+
+        return new CaseDispatchSymbol(
+            $this->kernel->findObject($hash),
+            $pos,
+            $len,
+        );
+    }
+}

--- a/src/VM/Core/Runtime/Kernel/Ruby3_2/Loader/RegexpSymbolLoader.php
+++ b/src/VM/Core/Runtime/Kernel/Ruby3_2/Loader/RegexpSymbolLoader.php
@@ -6,12 +6,12 @@ namespace RubyVM\VM\Core\Runtime\Kernel\Ruby3_2\Loader;
 
 use RubyVM\VM\Core\Runtime\Essential\KernelInterface;
 use RubyVM\VM\Core\YARV\Criterion\Offset\Offset;
-use RubyVM\VM\Core\YARV\Essential\Symbol\RegExpSymbol;
+use RubyVM\VM\Core\YARV\Essential\Symbol\RegexpSymbol;
 use RubyVM\VM\Core\YARV\Essential\Symbol\StringSymbol;
 use RubyVM\VM\Core\YARV\Essential\Symbol\SymbolInterface;
 use RubyVM\VM\Core\YARV\Essential\Symbol\SymbolLoaderInterface;
 
-class RegExpSymbolLoader implements SymbolLoaderInterface
+class RegexpSymbolLoader implements SymbolLoaderInterface
 {
     public function __construct(
         protected readonly KernelInterface $kernel,
@@ -28,7 +28,7 @@ class RegExpSymbolLoader implements SymbolLoaderInterface
 
         assert($sourceString instanceof StringSymbol);
 
-        return new RegExpSymbol(
+        return new RegexpSymbol(
             $sourceString,
             $option,
         );

--- a/src/VM/Core/YARV/Essential/Symbol/CaseDispatchSymbol.php
+++ b/src/VM/Core/YARV/Essential/Symbol/CaseDispatchSymbol.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RubyVM\VM\Core\YARV\Essential\Symbol;
+
+class CaseDispatchSymbol implements SymbolInterface, \Stringable
+{
+    public function __construct(
+        private readonly SymbolInterface $hash,
+        private readonly int $pos,
+        private readonly int $len,
+    ) {}
+
+    public function valueOf(): mixed
+    {
+        return $this->hash->valueOf();
+    }
+
+    public function __toString(): string
+    {
+        return '';
+    }
+
+    public function pos(): int
+    {
+        return $this->pos;
+    }
+
+    public function len(): int
+    {
+        return $this->len;
+    }
+}

--- a/src/VM/Core/YARV/Essential/Symbol/RegexpSymbol.php
+++ b/src/VM/Core/YARV/Essential/Symbol/RegexpSymbol.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace RubyVM\VM\Core\YARV\Essential\Symbol;
 
-class RegExpSymbol implements SymbolInterface, \Stringable
+class RegexpSymbol implements SymbolInterface, \Stringable
 {
     public function __construct(
         private readonly StringSymbol $source,

--- a/tests/Version/Ruby3_2/SyntaxTest.php
+++ b/tests/Version/Ruby3_2/SyntaxTest.php
@@ -916,4 +916,33 @@ class SyntaxTest extends TestApplication
 
         _, $rubyVMManager->stdOut->readAll());
     }
+
+    public function testCaseToNonElse(): void
+    {
+        $rubyVMManager = $this->createRubyVMFromCode(
+            <<< '_'
+            arr = 5
+            case arr
+            when 1 then
+              puts "1"
+            when 2 then
+              puts "2"
+            when 3 then
+              puts "3"
+            end
+
+            puts arr
+            _,
+        );
+
+        $executor = $rubyVMManager
+            ->rubyVM
+            ->disassemble(RubyVersion::VERSION_3_2);
+
+        $this->assertSame(ExecutedStatus::SUCCESS, $executor->execute()->executedStatus);
+        $this->assertSame(<<<'_'
+        5
+
+        _, $rubyVMManager->stdOut->readAll());
+    }
 }

--- a/tests/Version/Ruby3_2/SyntaxTest.php
+++ b/tests/Version/Ruby3_2/SyntaxTest.php
@@ -858,4 +858,62 @@ class SyntaxTest extends TestApplication
 
         _, $rubyVMManager->stdOut->readAll());
     }
+
+    public function testCase(): void
+    {
+        $rubyVMManager = $this->createRubyVMFromCode(
+            <<< '_'
+            arr = 3
+
+            case arr
+            when 1 then
+              puts "1"
+            when 2 then
+              puts "2"
+            when 3 then
+              puts "3"
+            end
+
+            _,
+        );
+
+        $executor = $rubyVMManager
+            ->rubyVM
+            ->disassemble(RubyVersion::VERSION_3_2);
+
+        $this->assertSame(ExecutedStatus::SUCCESS, $executor->execute()->executedStatus);
+        $this->assertSame(<<<'_'
+        3
+
+        _, $rubyVMManager->stdOut->readAll());
+    }
+
+    public function testCaseToElse(): void
+    {
+        $rubyVMManager = $this->createRubyVMFromCode(
+            <<< '_'
+            arr = 5
+            case arr
+            when 1 then
+              puts "1"
+            when 2 then
+              puts "2"
+            when 3 then
+              puts "3"
+            else
+              puts "else"
+            end
+            _,
+        );
+
+        $executor = $rubyVMManager
+            ->rubyVM
+            ->disassemble(RubyVersion::VERSION_3_2);
+
+        $this->assertSame(ExecutedStatus::SUCCESS, $executor->execute()->executedStatus);
+        $this->assertSame(<<<'_'
+        else
+
+        _, $rubyVMManager->stdOut->readAll());
+    }
 }


### PR DESCRIPTION
supports

```ruby
arr = 3

case arr
when 1 then
  puts "1"
when 2 then
  puts "2"
when 3 then
  puts "3"
end

```


```ruby
arr = 5

case arr
when 1 then
  puts "1"
when 2 then
  puts "2"
when 3 then
  puts "3"
else 
  puts "5"
end

```

```ruby
arr = 5

case arr
when 1 then
  puts "1"
when 2 then
  puts "2"
when 3 then
  puts "3"
end

puts arr

```

