### PR TITLE
Cosmetic changes

### DIFF
--- a/src/VM/Core/Runtime/BasicObject/Kernel/Object_/Comparable/Float_.php
+++ b/src/VM/Core/Runtime/BasicObject/Kernel/Object_/Comparable/Float_.php
@@ -16,6 +16,8 @@ class Float_ extends Comparable implements RubyClassInterface, Symbolize
 {
     use Symbolizable;
 
+    final public const INFINITY = INF;
+
     public function __construct(FloatSymbol $symbol)
     {
         $this->symbol = $symbol;

--- a/src/VM/Core/Runtime/BasicObject/Kernel/Object_/Comparable/Integer_.php
+++ b/src/VM/Core/Runtime/BasicObject/Kernel/Object_/Comparable/Integer_.php
@@ -185,6 +185,30 @@ class Integer_ extends Comparable implements RubyClassInterface, Symbolize
             : FalseClass::createBy();
     }
 
+    #[BindAliasAs('even?')]
+    public function isEven(CallInfoInterface $callInfo): TrueClass|FalseClass
+    {
+        return ($this->valueOf() & 1) === 0
+            ? TrueClass::createBy()
+            : FalseClass::createBy();
+    }
+
+    #[BindAliasAs('odd?')]
+    public function isOdd(CallInfoInterface $callInfo): TrueClass|FalseClass
+    {
+        return ($this->valueOf() & 1) === 1
+            ? TrueClass::createBy()
+            : FalseClass::createBy();
+    }
+
+    #[BindAliasAs('zero?')]
+    public function isZero(CallInfoInterface $callInfo): TrueClass|FalseClass
+    {
+        return $this->valueOf() === 0
+            ? TrueClass::createBy()
+            : FalseClass::createBy();
+    }
+
     public static function createBy(mixed $value = 0): self
     {
         return new self(new NumberSymbol($value));

--- a/src/VM/Core/Runtime/BasicObject/Kernel/Object_/Comparable/String_.php
+++ b/src/VM/Core/Runtime/BasicObject/Kernel/Object_/Comparable/String_.php
@@ -52,7 +52,7 @@ class String_ extends Comparable implements RubyClassInterface, Symbolize
     #[BindAliasAs('include?')]
     public function isIncluding(CallInfoInterface $callInfo, String_ $string): TrueClass|FalseClass
     {
-        return str_contains($this->valueOf(), $string->valueOf())
+        return str_contains((string) $this->valueOf(), (string) $string->valueOf())
             ? TrueClass::createBy()
             : FalseClass::createBy();
     }

--- a/src/VM/Core/Runtime/BasicObject/Kernel/Object_/Comparable/String_.php
+++ b/src/VM/Core/Runtime/BasicObject/Kernel/Object_/Comparable/String_.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace RubyVM\VM\Core\Runtime\BasicObject\Kernel\Object_\Comparable;
 
 use RubyVM\VM\Core\Runtime\Attribute\BindAliasAs;
+use RubyVM\VM\Core\Runtime\BasicObject\Kernel\Object_\FalseClass;
+use RubyVM\VM\Core\Runtime\BasicObject\Kernel\Object_\TrueClass;
 use RubyVM\VM\Core\Runtime\BasicObject\Symbolizable;
 use RubyVM\VM\Core\Runtime\BasicObject\Symbolize;
 use RubyVM\VM\Core\Runtime\Essential\RubyClassInterface;
@@ -37,5 +39,13 @@ class String_ extends Comparable implements RubyClassInterface, Symbolize
         return String_::createBy(
             $this->valueOf() . $object->valueOf(),
         );
+    }
+
+    #[BindAliasAs('empty?')]
+    public function isEmpty(CallInfoInterface $callInfo): TrueClass|FalseClass
+    {
+        return $this->valueOf() === ''
+            ? TrueClass::createBy()
+            : FalseClass::createBy();
     }
 }

--- a/src/VM/Core/Runtime/BasicObject/Kernel/Object_/Comparable/String_.php
+++ b/src/VM/Core/Runtime/BasicObject/Kernel/Object_/Comparable/String_.php
@@ -48,4 +48,12 @@ class String_ extends Comparable implements RubyClassInterface, Symbolize
             ? TrueClass::createBy()
             : FalseClass::createBy();
     }
+
+    #[BindAliasAs('include?')]
+    public function isIncluding(CallInfoInterface $callInfo, String_ $string): TrueClass|FalseClass
+    {
+        return str_contains($this->valueOf(), $string->valueOf())
+            ? TrueClass::createBy()
+            : FalseClass::createBy();
+    }
 }

--- a/src/VM/Core/Runtime/BasicObject/Kernel/Object_/Enumerable/Range.php
+++ b/src/VM/Core/Runtime/BasicObject/Kernel/Object_/Enumerable/Range.php
@@ -28,7 +28,7 @@ class Range extends Enumerable implements RubyClassInterface, Symbolize
 
     public function each(CallInfoInterface $callInfo, ContextInterface $context): RubyClassInterface
     {
-        foreach ($this->symbol->valueOf() as $index => $number) {
+        foreach ($this->symbol as $index => $number) {
             $executor = (new Executor(
                 kernel: $context->kernel(),
                 rubyClass: $context->self(),

--- a/src/VM/Core/Runtime/BasicObject/Kernel/Object_/Enumerable/Range.php
+++ b/src/VM/Core/Runtime/BasicObject/Kernel/Object_/Enumerable/Range.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace RubyVM\VM\Core\Runtime\BasicObject\Kernel\Object_\Enumerable;
 
 use RubyVM\VM\Core\Helper\ClassHelper;
+use RubyVM\VM\Core\Runtime\Attribute\BindAliasAs;
 use RubyVM\VM\Core\Runtime\BasicObject\Kernel\Object_\Comparable\Integer_;
+use RubyVM\VM\Core\Runtime\BasicObject\Kernel\Object_\FalseClass;
 use RubyVM\VM\Core\Runtime\BasicObject\Kernel\Object_\NilClass;
+use RubyVM\VM\Core\Runtime\BasicObject\Kernel\Object_\TrueClass;
 use RubyVM\VM\Core\Runtime\BasicObject\Symbolizable;
 use RubyVM\VM\Core\Runtime\BasicObject\Symbolize;
 use RubyVM\VM\Core\Runtime\Essential\RubyClassInterface;
@@ -28,6 +31,8 @@ class Range extends Enumerable implements RubyClassInterface, Symbolize
 
     public function each(CallInfoInterface $callInfo, ContextInterface $context): RubyClassInterface
     {
+        assert($this->symbol instanceof \Traversable);
+
         foreach ($this->symbol as $index => $number) {
             $executor = (new Executor(
                 kernel: $context->kernel(),
@@ -102,7 +107,7 @@ class Range extends Enumerable implements RubyClassInterface, Symbolize
     {
         assert($this->symbol instanceof RangeSymbol);
 
-        return $this->symbol->getIterator();
+        return $this->symbol;
     }
 
     public function count(): int
@@ -110,5 +115,19 @@ class Range extends Enumerable implements RubyClassInterface, Symbolize
         assert($this->symbol instanceof RangeSymbol);
 
         return $this->symbol->count();
+    }
+
+    #[BindAliasAs('===')]
+    public function compareStrictEquals(CallInfoInterface $callInfo, RubyClassInterface $object): TrueClass|FalseClass
+    {
+        assert($this->symbol instanceof RangeSymbol);
+
+        if ($this->symbol->isInfinity() && $object->valueOf() === INF) {
+            return TrueClass::createBy();
+        }
+
+        return $this->valueOf() === $object->valueOf()
+            ? TrueClass::createBy()
+            : FalseClass::createBy();
     }
 }

--- a/src/VM/Core/Runtime/BasicObject/Kernel/Object_/FalseClass.php
+++ b/src/VM/Core/Runtime/BasicObject/Kernel/Object_/FalseClass.php
@@ -24,6 +24,7 @@ class FalseClass extends Object_ implements RubyClassInterface, Symbolize
     public static function createBy(): self
     {
         static $cache;
+
         return $cache ??= new self();
     }
 

--- a/src/VM/Core/Runtime/BasicObject/Kernel/Object_/FalseClass.php
+++ b/src/VM/Core/Runtime/BasicObject/Kernel/Object_/FalseClass.php
@@ -23,7 +23,8 @@ class FalseClass extends Object_ implements RubyClassInterface, Symbolize
 
     public static function createBy(): self
     {
-        return new self();
+        static $cache;
+        return $cache ??= new self();
     }
 
     #[BindAliasAs('to_s')]

--- a/src/VM/Core/Runtime/BasicObject/Kernel/Object_/NilClass.php
+++ b/src/VM/Core/Runtime/BasicObject/Kernel/Object_/NilClass.php
@@ -26,6 +26,7 @@ class NilClass extends Object_ implements RubyClassInterface
     public static function createBy(mixed $value = null): self
     {
         static $cache;
+
         return $cache ??= new self(new NilSymbol());
     }
 }

--- a/src/VM/Core/Runtime/BasicObject/Kernel/Object_/NilClass.php
+++ b/src/VM/Core/Runtime/BasicObject/Kernel/Object_/NilClass.php
@@ -25,8 +25,7 @@ class NilClass extends Object_ implements RubyClassInterface
 
     public static function createBy(mixed $value = null): self
     {
-        static $symbol = new NilSymbol();
-
-        return new self($symbol);
+        static $cache;
+        return $cache ??= new self(new NilSymbol());
     }
 }

--- a/src/VM/Core/Runtime/BasicObject/Kernel/Object_/Object_.php
+++ b/src/VM/Core/Runtime/BasicObject/Kernel/Object_/Object_.php
@@ -10,7 +10,6 @@ use RubyVM\VM\Core\YARV\Criterion\InstructionSequence\CallInfoInterface;
 
 abstract class Object_ extends Kernel
 {
-
     #[BindAliasAs('nil?')]
     public function isNil(CallInfoInterface $callInfo): TrueClass|FalseClass
     {

--- a/src/VM/Core/Runtime/BasicObject/Kernel/Object_/Object_.php
+++ b/src/VM/Core/Runtime/BasicObject/Kernel/Object_/Object_.php
@@ -4,6 +4,18 @@ declare(strict_types=1);
 
 namespace RubyVM\VM\Core\Runtime\BasicObject\Kernel\Object_;
 
+use RubyVM\VM\Core\Runtime\Attribute\BindAliasAs;
 use RubyVM\VM\Core\Runtime\BasicObject\Kernel\Kernel;
+use RubyVM\VM\Core\YARV\Criterion\InstructionSequence\CallInfoInterface;
 
-abstract class Object_ extends Kernel {}
+abstract class Object_ extends Kernel
+{
+
+    #[BindAliasAs('nil?')]
+    public function isNil(CallInfoInterface $callInfo): TrueClass|FalseClass
+    {
+        return $this instanceof NilClass || $this->valueOf() === null
+            ? TrueClass::createBy()
+            : FalseClass::createBy();
+    }
+}

--- a/src/VM/Core/Runtime/BasicObject/Kernel/Object_/TrueClass.php
+++ b/src/VM/Core/Runtime/BasicObject/Kernel/Object_/TrueClass.php
@@ -23,7 +23,8 @@ class TrueClass extends Object_ implements RubyClassInterface, Symbolize
 
     public static function createBy(): self
     {
-        return new self();
+        static $cache;
+        return $cache ??= new self();
     }
 
     #[BindAliasAs('to_s')]

--- a/src/VM/Core/Runtime/BasicObject/Kernel/Object_/TrueClass.php
+++ b/src/VM/Core/Runtime/BasicObject/Kernel/Object_/TrueClass.php
@@ -24,6 +24,7 @@ class TrueClass extends Object_ implements RubyClassInterface, Symbolize
     public static function createBy(): self
     {
         static $cache;
+
         return $cache ??= new self();
     }
 

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinBranchif.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinBranchif.php
@@ -33,9 +33,9 @@ class BuiltinBranchif implements OperationProcessorInterface
 
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
-        $offset = $this->getOperandAsOffset();
+        $offset = $this->operandAsOffset();
 
-        $entity = $this->getStackAsEntity();
+        $entity = $this->stackAsRubyClass();
 
         if ($entity->testValue()) {
             $this->context

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinBranchunless.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinBranchunless.php
@@ -33,9 +33,9 @@ class BuiltinBranchunless implements OperationProcessorInterface
 
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
-        $offset = $this->getOperandAsOffset();
+        $offset = $this->operandAsOffset();
 
-        $entity = $this->getStackAsEntity();
+        $entity = $this->stackAsRubyClass();
 
         if (!$entity->testValue()) {
             $this->context

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinCheckmatch.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinCheckmatch.php
@@ -38,15 +38,15 @@ class BuiltinCheckmatch implements OperationProcessorInterface
         // 1 ... WHEN
         // 2 ... CASE
         // 3 ... RESCUE
-        $type = $this->getOperandAsNumber();
+        $type = $this->operandAsNumber();
 
         // TODO: We will implement other types
         if ($type->valueOf() !== CheckMatchType::RESCUE->value) {
             throw new OperationProcessorException(sprintf('The `%s` (opcode: 0x%02x) processor with %d type is not implemented yet', strtolower($this->insn->name), $this->insn->value, $type->valueOf()));
         }
 
-        $compareBy = $this->getStackAsRubyClass();
-        $compareFrom = $this->getStackAsRubyClass();
+        $compareBy = $this->stackAsRubyClass();
+        $compareFrom = $this->stackAsRubyClass();
 
         $this->context
             ->vmStack()

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinDefineclass.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinDefineclass.php
@@ -39,9 +39,9 @@ class BuiltinDefineclass implements OperationProcessorInterface
 
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
-        $className = ClassCreator::createClassBySymbol($this->getOperandAsID()->object);
-        $iseqNumber = $this->getOperandAsNumber();
-        $flags = $this->getOperandAsNumber();
+        $className = ClassCreator::createClassBySymbol($this->operandAsID()->object);
+        $iseqNumber = $this->operandAsNumber();
+        $flags = $this->operandAsNumber();
 
         $instructionSequence = $this->context->kernel()
             ->loadInstructionSequence(

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinDefinemethod.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinDefinemethod.php
@@ -39,7 +39,7 @@ class BuiltinDefinemethod implements OperationProcessorInterface
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
         $methodName = ClassCreator::createClassBySymbol(
-            $this->getOperandAsID()
+            $this->operandAsID()
                 ->object
         );
 
@@ -47,7 +47,7 @@ class BuiltinDefinemethod implements OperationProcessorInterface
             ->loadInstructionSequence(
                 aux: new Aux(
                     loader: new AuxLoader(
-                        index: $this->getOperandAsNumber()
+                        index: $this->operandAsNumber()
                             ->valueOf(),
                     ),
                 ),

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinDuparray.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinDuparray.php
@@ -35,7 +35,7 @@ class BuiltinDuparray implements OperationProcessorInterface
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
         $this->context->vmStack()->push(new Operand(
-            $this->getOperandAsArray()
+            $this->operandAsArray()
                 ->setRuntimeContext($this->context),
         ));
 

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinGetglobal.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinGetglobal.php
@@ -31,7 +31,7 @@ class BuiltinGetglobal implements OperationProcessorInterface
 
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
-        $operand = $this->getOperandAsID();
+        $operand = $this->operandAsID();
 
         $value = $this->context
             ->kernel()

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinGetinstancevariable.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinGetinstancevariable.php
@@ -32,15 +32,15 @@ class BuiltinGetinstancevariable implements OperationProcessorInterface
 
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
-        $instanceVar = $this->getOperandAsID();
+        $instanceVar = $this->operandAsID();
 
         // this is instance variable index
-        $ivIndex = $this->getOperandAsNumber()->valueOf();
+        $ivIndex = $this->operandAsNumber()->valueOf();
 
         /**
          * @var RubyClassImplementationInterface $targetObject
          */
-        $targetObject = $this->getStackAsRubyClass();
+        $targetObject = $this->stackAsRubyClass();
 
         $this->context->vmStack()->push(
             new Operand(

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinGetlocal.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinGetlocal.php
@@ -33,8 +33,8 @@ class BuiltinGetlocal implements OperationProcessorInterface
 
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
-        $slotIndex = $this->getOperandAsNumber()->valueOf();
-        $level = $this->getOperandAsNumber()->valueOf();
+        $slotIndex = $this->operandAsNumber()->valueOf();
+        $level = $this->operandAsNumber()->valueOf();
 
         $this->getLocalTableToStack($slotIndex, $level);
 

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinGetlocalWC0.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinGetlocalWC0.php
@@ -34,7 +34,7 @@ class BuiltinGetlocalWC0 implements OperationProcessorInterface
 
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
-        $slotIndex = $this->getOperandAsNumber()->valueOf();
+        $slotIndex = $this->operandAsNumber()->valueOf();
         $this->getLocalTableToStack($slotIndex, Option::RSV_TABLE_INDEX_0);
 
         return ProcessedStatus::SUCCESS;

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinGetlocalWC1.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinGetlocalWC1.php
@@ -34,7 +34,7 @@ class BuiltinGetlocalWC1 implements OperationProcessorInterface
 
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
-        $slotIndex = $this->getOperandAsNumber()->valueOf();
+        $slotIndex = $this->operandAsNumber()->valueOf();
         $this->getLocalTableToStack($slotIndex, Option::RSV_TABLE_INDEX_1);
 
         return ProcessedStatus::SUCCESS;

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinInvokeblock.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinInvokeblock.php
@@ -52,11 +52,11 @@ class BuiltinInvokeblock implements OperationProcessorInterface
         // This is an operation processor context including instruction sequence context
         $processorContext = $arguments[0];
 
-        $operand = $this->getOperandAsCallInfo();
+        $operand = $this->operandAsCallInfo();
         $arguments = [];
 
         for ($i = 0; $i < $operand->callData()->argumentsCount(); ++$i) {
-            $arguments[] = $this->getStackAsObject();
+            $arguments[] = $this->stackAsObject();
         }
 
         $executed = $this

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinJump.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinJump.php
@@ -30,7 +30,7 @@ class BuiltinJump implements OperationProcessorInterface
 
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
-        $operand = $this->getOperandAsOffset();
+        $operand = $this->operandAsOffset();
 
         $this->context
             ->programCounter()

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinNewarray.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinNewarray.php
@@ -33,10 +33,10 @@ class BuiltinNewarray implements OperationProcessorInterface
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
         $entries = [];
-        $num = $this->getOperandAsNumber();
+        $num = $this->operandAsNumber();
 
         for ($i = $num->valueOf() - 1; $i >= 0; --$i) {
-            $entries[$i] = $this->getStackAsEntity();
+            $entries[$i] = $this->stackAsRubyClass();
         }
 
         $this->context->vmStack()->push(

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinNewhash.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinNewhash.php
@@ -32,11 +32,11 @@ class BuiltinNewhash implements OperationProcessorInterface
 
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
-        $number = $this->getOperandAsNumber();
+        $number = $this->operandAsNumber();
         $newHash = new Hash();
         for ($i = 0; $i < ($number->valueOf() / 2); ++$i) {
-            $value = $this->getStackAsEntity();
-            $name = $this->getStackAsSymbol();
+            $value = $this->stackAsRubyClass();
+            $name = $this->stackAsSymbol();
 
             $newHash[(string) $name] = $value;
         }

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinNewrange.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinNewrange.php
@@ -36,17 +36,17 @@ class BuiltinNewrange implements OperationProcessorInterface
 
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
-        $flags = $this->getOperandAsNumber();
+        $flags = $this->operandAsNumber();
 
         /**
          * @var NumberSymbol $high
          */
-        $high = $this->getStackAsNumber();
+        $high = $this->stackAsNumber();
 
         /**
          * @var NumberSymbol $low
          */
-        $low = $this->getStackAsNumber();
+        $low = $this->stackAsNumber();
 
         if (!$high instanceof Symbolize || !$low instanceof Symbolize) {
             throw new OperationProcessorException(

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinOptAref.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinOptAref.php
@@ -34,10 +34,10 @@ class BuiltinOptAref implements OperationProcessorInterface
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
         // No used (This operand is only array always; which calls [] in the ruby and refs array symbol)
-        $this->getOperand();
+        $this->operand();
 
-        $recv = $this->getStackAsEntity();
-        $obj = $this->getStackAsAny(RubyClassInterface::class);
+        $recv = $this->stackAsRubyClass();
+        $obj = $this->stackAsAny(RubyClassInterface::class);
 
         if ($obj instanceof \ArrayAccess) {
             $value = $obj[$recv->valueOf()] ?? null;

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinOptCaseDispatch.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinOptCaseDispatch.php
@@ -30,9 +30,9 @@ class BuiltinOptCaseDispatch implements OperationProcessorInterface
 
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
-        $hash = $this->getOperandAsID();
-        $elseOffset = $this->getOperandAsRubyClass();
-        $key = $this->getStackAsRubyClass();
+        $hash = $this->operandAsID();
+        $elseOffset = $this->operandAsRubyClass();
+        $key = $this->stackAsRubyClass();
 
         if ($key->valueOf() !== $hash->object->valueOf()) {
             $this->context

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinOptEmptyP.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinOptEmptyP.php
@@ -32,8 +32,8 @@ class BuiltinOptEmptyP implements OperationProcessorInterface
 
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
-        $class = $this->getStackAsEntity();
-        $callInfo = $this->getOperandAsCallInfo();
+        $class = $this->stackAsRubyClass();
+        $callInfo = $this->operandAsCallInfo();
 
         $methodName = (string) $callInfo
             ->callData()

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinOptEmptyP.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinOptEmptyP.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace RubyVM\VM\Core\Runtime\Executor\Insn\Processor;
 
+use RubyVM\VM\Core\Runtime\BasicObject\Kernel\Object_\NilClass;
 use RubyVM\VM\Core\Runtime\Essential\RubyClassInterface;
 use RubyVM\VM\Core\Runtime\Executor\Context\ContextInterface;
 use RubyVM\VM\Core\Runtime\Executor\Insn\Insn;
+use RubyVM\VM\Core\Runtime\Executor\Operation\Operand;
 use RubyVM\VM\Core\Runtime\Executor\Operation\OperandHelper;
 use RubyVM\VM\Core\Runtime\Executor\Operation\Processor\OperationProcessorInterface;
 use RubyVM\VM\Core\Runtime\Executor\ProcessedStatus;
-use RubyVM\VM\Exception\OperationProcessorException;
 
 class BuiltinOptEmptyP implements OperationProcessorInterface
 {
@@ -31,6 +32,31 @@ class BuiltinOptEmptyP implements OperationProcessorInterface
 
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
-        throw new OperationProcessorException(sprintf('The `%s` (opcode: 0x%02x) processor is not implemented yet', strtolower($this->insn->name), $this->insn->value));
+        $class = $this->getStackAsEntity();
+        $callInfo = $this->getOperandAsCallInfo();
+
+        $methodName = (string) $callInfo
+            ->callData()
+            ->mid()
+            ->object;
+
+        /**
+         * @var null|RubyClassInterface $result
+         */
+        $result = $class
+            ->setRuntimeContext($this->context)
+            ->{$methodName}($callInfo);
+
+        if ($result === null) {
+            $result = NilClass::createBy();
+        }
+
+        $this->context->vmStack()->push(
+            new Operand(
+                $result,
+            ),
+        );
+
+        return ProcessedStatus::SUCCESS;
     }
 }

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinOptGetconstantPath.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinOptGetconstantPath.php
@@ -34,7 +34,7 @@ class BuiltinOptGetconstantPath implements OperationProcessorInterface
 
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
-        $operand = $this->getOperandAsID();
+        $operand = $this->operandAsID();
 
         $symbol = $operand->object;
 

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinOptGetconstantPath.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinOptGetconstantPath.php
@@ -38,6 +38,7 @@ class BuiltinOptGetconstantPath implements OperationProcessorInterface
 
         $symbol = $operand->object;
 
+        $current = null;
         foreach ($symbol->valueOf() as $constantNameSymbol) {
             $classes = $this->context->self()->userlandHeapSpace()->userlandClasses();
 
@@ -60,7 +61,24 @@ class BuiltinOptGetconstantPath implements OperationProcessorInterface
 
                 $object = $className::createBy();
             } else {
-                $object = Class_::of($constantNameSymbol, $this->context);
+                $object = $constantNameSymbol;
+                if ($current === null) {
+                    $object = Class_::of($constantNameSymbol, $this->context);
+                } else {
+                    $reflectionClass = new \ReflectionClass($current);
+                    $constant = $reflectionClass
+                        ->getConstant(
+                            $constantNameSymbol
+                                ->valueOf(),
+                        );
+
+                    if ($constant !== false) {
+                        $object = $current::createBy($constant);
+                    } else {
+                        // TODO lookup class correctly
+                        $object = Class_::of($constantNameSymbol, $this->context);
+                    }
+                }
             }
 
             $heapSpace = $classes->get($constantNameSymbol->valueOf());
@@ -79,8 +97,12 @@ class BuiltinOptGetconstantPath implements OperationProcessorInterface
             $object->setRuntimeContext($this->context)
                 ->setUserlandHeapSpace($object->userlandHeapSpace());
 
-            $this->context->vmStack()->push(new Operand($object));
+            $current = $object;
         }
+
+        assert($current !== null);
+
+        $this->context->vmStack()->push(new Operand($current));
 
         return ProcessedStatus::SUCCESS;
     }

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinOptNilP.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinOptNilP.php
@@ -32,8 +32,8 @@ class BuiltinOptNilP implements OperationProcessorInterface
 
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
-        $class = $this->getStackAsEntity();
-        $callInfo = $this->getOperandAsCallInfo();
+        $class = $this->stackAsRubyClass();
+        $callInfo = $this->operandAsCallInfo();
 
         $methodName = (string) $callInfo
             ->callData()

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinOptNilP.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinOptNilP.php
@@ -7,7 +7,6 @@ namespace RubyVM\VM\Core\Runtime\Executor\Insn\Processor;
 use RubyVM\VM\Core\Runtime\BasicObject\Kernel\Object_\NilClass;
 use RubyVM\VM\Core\Runtime\Essential\RubyClassInterface;
 use RubyVM\VM\Core\Runtime\Executor\Context\ContextInterface;
-use RubyVM\VM\Core\Runtime\Executor\ExecutedResult;
 use RubyVM\VM\Core\Runtime\Executor\Insn\Insn;
 use RubyVM\VM\Core\Runtime\Executor\Operation\Operand;
 use RubyVM\VM\Core\Runtime\Executor\Operation\OperandHelper;
@@ -42,7 +41,7 @@ class BuiltinOptNilP implements OperationProcessorInterface
             ->object;
 
         /**
-         * @var RubyClassInterface|null $result
+         * @var null|RubyClassInterface $result
          */
         $result = $class
             ->setRuntimeContext($this->context)

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinOptNilP.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinOptNilP.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace RubyVM\VM\Core\Runtime\Executor\Insn\Processor;
 
+use RubyVM\VM\Core\Runtime\BasicObject\Kernel\Object_\NilClass;
 use RubyVM\VM\Core\Runtime\Essential\RubyClassInterface;
 use RubyVM\VM\Core\Runtime\Executor\Context\ContextInterface;
 use RubyVM\VM\Core\Runtime\Executor\ExecutedResult;
@@ -12,7 +13,6 @@ use RubyVM\VM\Core\Runtime\Executor\Operation\Operand;
 use RubyVM\VM\Core\Runtime\Executor\Operation\OperandHelper;
 use RubyVM\VM\Core\Runtime\Executor\Operation\Processor\OperationProcessorInterface;
 use RubyVM\VM\Core\Runtime\Executor\ProcessedStatus;
-use RubyVM\VM\Exception\OperationProcessorException;
 
 class BuiltinOptNilP implements OperationProcessorInterface
 {
@@ -42,21 +42,19 @@ class BuiltinOptNilP implements OperationProcessorInterface
             ->object;
 
         /**
-         * @var RubyClassInterface|ExecutedResult $result
+         * @var RubyClassInterface|null $result
          */
         $result = $class
             ->setRuntimeContext($this->context)
             ->{$methodName}($callInfo);
 
-        if ($result instanceof ExecutedResult && $result->threw) {
-            throw $result->threw;
+        if ($result === null) {
+            $result = NilClass::createBy();
         }
 
         $this->context->vmStack()->push(
             new Operand(
-                $result instanceof RubyClassInterface
-                    ? $result
-                    : $result->returnValue,
+                $result,
             ),
         );
 

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinOptRegexpmatch2.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinOptRegexpmatch2.php
@@ -34,10 +34,10 @@ class BuiltinOptRegexpmatch2 implements OperationProcessorInterface
      */
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
-        $callInfo = $this->getOperandAsCallInfo();
+        $callInfo = $this->operandAsCallInfo();
 
-        $source = $this->getStackAsStringOrNil();
-        $regexp = $this->getStackAsRegExp();
+        $source = $this->stackAsStringOrNil();
+        $regexp = $this->stackAsRegExp();
 
         $this->context->vmStack()->push(
             new Operand(

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinOptSendWithoutBlock.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinOptSendWithoutBlock.php
@@ -46,7 +46,7 @@ class BuiltinOptSendWithoutBlock implements OperationProcessorInterface
 
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
-        $callInfo = $this->getOperandAsCallInfo();
+        $callInfo = $this->operandAsCallInfo();
 
         /**
          * @var StringSymbol $symbol

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinOptSize.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinOptSize.php
@@ -36,9 +36,9 @@ class BuiltinOptSize implements OperationProcessorInterface
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
         // No used
-        $this->getOperand();
+        $this->operand();
 
-        $recv = $this->getStackAsEntity();
+        $recv = $this->stackAsRubyClass();
 
         if ($recv instanceof Array_) {
             $this->context->vmStack()->push(

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinPutobject.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinPutobject.php
@@ -34,7 +34,7 @@ class BuiltinPutobject implements OperationProcessorInterface
 
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
-        $operand = $this->getOperandAsRubyClass();
+        $operand = $this->operandAsRubyClass();
         $operand
             ->setUserlandHeapSpace(
                 $operand

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinPutspecialobject.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinPutspecialobject.php
@@ -35,7 +35,7 @@ class BuiltinPutspecialobject implements OperationProcessorInterface
 
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
-        $symbol = $this->getOperandAsNumber();
+        $symbol = $this->operandAsNumber();
 
         $type = VMSpecialObjectType::of($symbol->valueOf());
 

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinSend.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinSend.php
@@ -38,7 +38,7 @@ class BuiltinSend implements OperationProcessorInterface
 
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
-        $callInfo = $this->getOperandAsCallInfo();
+        $callInfo = $this->operandAsCallInfo();
 
         $arguments = [];
         for ($i = 0; $i < $callInfo->callData()->argumentsCount(); ++$i) {
@@ -50,9 +50,9 @@ class BuiltinSend implements OperationProcessorInterface
             ...$arguments,
         );
 
-        $blockObject = $this->getStackAsRubyClass();
+        $blockObject = $this->stackAsRubyClass();
 
-        $blockIseqNumber = $this->getOperandAsNumber();
+        $blockIseqNumber = $this->operandAsNumber();
 
         $result = $this->callBlockWithArguments(
             $callInfo,

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinSetglobal.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinSetglobal.php
@@ -30,8 +30,8 @@ class BuiltinSetglobal implements OperationProcessorInterface
 
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
-        $operand = $this->getOperandAsID();
-        $value = $this->getStackAsEntity();
+        $operand = $this->operandAsID();
+        $value = $this->stackAsRubyClass();
 
         $this->context
             ->kernel()

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinSetinstancevariable.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinSetinstancevariable.php
@@ -30,12 +30,12 @@ class BuiltinSetinstancevariable implements OperationProcessorInterface
 
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
-        $instanceVar = $this->getOperandAsID();
+        $instanceVar = $this->operandAsID();
 
         // this is instance variable index
-        $ivIndex = $this->getOperandAsNumber()->valueOf();
+        $ivIndex = $this->operandAsNumber()->valueOf();
 
-        $targetObject = $this->getStackAsObject();
+        $targetObject = $this->stackAsObject();
 
         // TODO: is correctly here? we will implement iv or ivc pattern.
         $this->context

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinSetlocal.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinSetlocal.php
@@ -32,8 +32,8 @@ class BuiltinSetlocal implements OperationProcessorInterface
 
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
-        $slotIndex = $this->getOperandAsNumber()->valueOf();
-        $level = $this->getOperandAsNumber()->valueOf();
+        $slotIndex = $this->operandAsNumber()->valueOf();
+        $level = $this->operandAsNumber()->valueOf();
         $this->setLocalTableFromStack($slotIndex, $level);
 
         return ProcessedStatus::SUCCESS;

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinSetlocalWC0.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinSetlocalWC0.php
@@ -36,7 +36,7 @@ class BuiltinSetlocalWC0 implements OperationProcessorInterface
 
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
-        $slotIndex = $this->getOperandAsNumber()->valueOf();
+        $slotIndex = $this->operandAsNumber()->valueOf();
         $this->setLocalTableFromStack($slotIndex, Option::RSV_TABLE_INDEX_0);
 
         return ProcessedStatus::SUCCESS;

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinSetlocalWC1.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinSetlocalWC1.php
@@ -34,7 +34,7 @@ class BuiltinSetlocalWC1 implements OperationProcessorInterface
 
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
-        $slotIndex = $this->getOperandAsNumber()->valueOf();
+        $slotIndex = $this->operandAsNumber()->valueOf();
         $this->setLocalTableFromStack($slotIndex, Option::RSV_TABLE_INDEX_1);
 
         return ProcessedStatus::SUCCESS;

--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinTopn.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinTopn.php
@@ -31,7 +31,7 @@ class BuiltinTopn implements OperationProcessorInterface
 
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
-        $n = $this->getOperandAsNumber();
+        $n = $this->operandAsNumber();
         $stacks = [];
 
         // Get to specified value

--- a/src/VM/Core/Runtime/Executor/LocalTable.php
+++ b/src/VM/Core/Runtime/Executor/LocalTable.php
@@ -35,7 +35,7 @@ trait LocalTable
 
     public function setLocalTableFromStack(int $slotIndex, int $level): void
     {
-        $operand = $this->getStackAsObject();
+        $operand = $this->stackAsObject();
 
         $this->context->environmentTable()
             ->set(

--- a/src/VM/Core/Runtime/Executor/Operation/OperandHelper.php
+++ b/src/VM/Core/Runtime/Executor/Operation/OperandHelper.php
@@ -25,9 +25,9 @@ trait OperandHelper
 {
     use Validatable;
 
-    private function getOperandAsEntity(): RubyClassInterface
+    private function operandAsRubyClass(): RubyClassInterface
     {
-        $operand = $this->getOperandAsAny(
+        $operand = $this->operandAsAny(
             RubyClassInterface::class,
         );
 
@@ -36,12 +36,12 @@ trait OperandHelper
         return $operand;
     }
 
-    private function getOperandAsNumber(): Integer_
+    private function operandAsNumber(): Integer_
     {
         /**
          * @var Integer_ $number
          */
-        $number = $this->getOperandAsEntity();
+        $number = $this->operandAsRubyClass();
 
         $this->validateType(
             Integer_::class,
@@ -51,12 +51,12 @@ trait OperandHelper
         return $number;
     }
 
-    private function getOperandAsString(): String_
+    private function operandAsString(): String_
     {
         /**
          * @var String_ $entity
          */
-        $entity = $this->getOperandAsEntity();
+        $entity = $this->operandAsRubyClass();
 
         $this->validateType(
             String_::class,
@@ -66,12 +66,12 @@ trait OperandHelper
         return $entity;
     }
 
-    private function getOperandAsFloat(): Float_
+    private function operandAsFloat(): Float_
     {
         /**
          * @var Float_ $entity
          */
-        $entity = $this->getOperandAsEntity();
+        $entity = $this->operandAsRubyClass();
 
         $this->validateType(
             Float_::class,
@@ -81,12 +81,12 @@ trait OperandHelper
         return $entity;
     }
 
-    private function getOperandAsOffset(): Offset
+    private function operandAsOffset(): Offset
     {
         /**
          * @var Offset $entity
          */
-        $entity = $this->getOperandAsEntity();
+        $entity = $this->operandAsRubyClass();
 
         $this->validateType(
             Offset::class,
@@ -96,12 +96,12 @@ trait OperandHelper
         return $entity;
     }
 
-    private function getOperandAsArray(): Array_
+    private function operandAsArray(): Array_
     {
         /**
          * @var Array_ $entity
          */
-        $entity = $this->getOperandAsEntity();
+        $entity = $this->operandAsRubyClass();
 
         $this->validateType(
             Array_::class,
@@ -111,46 +111,38 @@ trait OperandHelper
         return $entity;
     }
 
-    private function getOperandAsID(): ID
+    private function operandAsID(): ID
     {
-        $value = $this->getOperandAsAny(ID::class);
+        $value = $this->operandAsAny(ID::class);
         assert($value instanceof ID);
 
         return $value;
     }
 
-    private function getOperandAsRubyClass(): RubyClassInterface
+    private function operandAsCallInfo(): CallInfoInterface
     {
-        $value = $this->getOperandAsAny(RubyClassInterface::class);
-        assert($value instanceof RubyClassInterface);
-
-        return $value;
-    }
-
-    private function getOperandAsCallInfo(): CallInfoInterface
-    {
-        $value = $this->getOperandAsAny(CallInfoInterface::class);
+        $value = $this->operandAsAny(CallInfoInterface::class);
         assert($value instanceof CallInfoInterface);
 
         return $value;
     }
 
-    private function getOperandAsExecutedResult(): ExecutedResult
+    private function operandAsExecutedResult(): ExecutedResult
     {
-        $value = $this->getOperandAsAny(ExecutedResult::class);
+        $value = $this->operandAsAny(ExecutedResult::class);
         assert($value instanceof ExecutedResult);
 
         return $value;
     }
 
-    private function getOperandAsObject(): RubyClassInterface
+    private function operandAsObject(): RubyClassInterface
     {
-        return $this->getOperandAsRubyClass()
+        return $this->operandAsRubyClass()
             ->setRuntimeContext($this->context)
             ->setUserlandHeapSpace($this->context->self()->userlandHeapSpace());
     }
 
-    private function getOperand(): Operand
+    private function operand(): Operand
     {
         /**
          * @var Operand $operand
@@ -170,9 +162,9 @@ trait OperandHelper
         return $operand;
     }
 
-    private function getOperandAsAny(string $className): CallInfoInterface|RubyClassInterface|ID|ExecutedResult
+    private function operandAsAny(string $className): CallInfoInterface|RubyClassInterface|ID|ExecutedResult
     {
-        $operand = $this->getOperand();
+        $operand = $this->operand();
 
         $this->validateType(
             $className,
@@ -182,9 +174,9 @@ trait OperandHelper
         return $operand->operand;
     }
 
-    private function getStackAsEntity(): RubyClassInterface
+    private function stackAsRubyClass(): RubyClassInterface
     {
-        $stack = $this->getStackAsAny(
+        $stack = $this->stackAsAny(
             RubyClassInterface::class
         );
 
@@ -193,12 +185,12 @@ trait OperandHelper
         return $stack;
     }
 
-    private function getStackAsSymbol(): Symbol
+    private function stackAsSymbol(): Symbol
     {
         /**
          * @var Symbol $entity
          */
-        $entity = $this->getStackAsEntity();
+        $entity = $this->stackAsRubyClass();
 
         $this->validateType(
             Symbol::class,
@@ -208,12 +200,12 @@ trait OperandHelper
         return $entity;
     }
 
-    private function getStackAsNumber(): Integer_
+    private function stackAsNumber(): Integer_
     {
         /**
          * @var Integer_ $entity
          */
-        $entity = $this->getStackAsEntity();
+        $entity = $this->stackAsRubyClass();
 
         $this->validateType(
             Integer_::class,
@@ -223,12 +215,12 @@ trait OperandHelper
         return $entity;
     }
 
-    private function getStackAsArray(): Array_
+    private function stackAsArray(): Array_
     {
         /**
          * @var Array_ $entity
          */
-        $entity = $this->getStackAsEntity();
+        $entity = $this->stackAsRubyClass();
 
         $this->validateType(
             Array_::class,
@@ -238,12 +230,12 @@ trait OperandHelper
         return $entity;
     }
 
-    private function getStackAsString(): String_
+    private function stackAsString(): String_
     {
         /**
          * @var String_ $entity
          */
-        $entity = $this->getStackAsEntity();
+        $entity = $this->stackAsRubyClass();
 
         $this->validateType(
             String_::class,
@@ -255,21 +247,21 @@ trait OperandHelper
         return $entity;
     }
 
-    private function getStackAsStringOrNil(): String_|NilClass
+    private function stackAsStringOrNil(): String_|NilClass
     {
-        $entity = $this->getStackAsEntity();
+        $entity = $this->stackAsRubyClass();
 
         assert($entity instanceof String_ || $entity instanceof NilClass);
 
         return $entity;
     }
 
-    private function getStackAsRegExp(): Regexp
+    private function stackAsRegExp(): Regexp
     {
         /**
          * @var Regexp $entity
          */
-        $entity = $this->getStackAsEntity();
+        $entity = $this->stackAsRubyClass();
 
         $this->validateType(
             Regexp::class,
@@ -281,12 +273,12 @@ trait OperandHelper
         return $entity;
     }
 
-    private function getStackAsFloat(): Float_
+    private function stackAsFloat(): Float_
     {
         /**
          * @var Float_ $entity
          */
-        $entity = $this->getStackAsEntity();
+        $entity = $this->stackAsRubyClass();
 
         $this->validateType(
             Float_::class,
@@ -298,12 +290,12 @@ trait OperandHelper
         return $entity;
     }
 
-    private function getStackAsOffsetSymbol(): Offset
+    private function stackAsOffsetSymbol(): Offset
     {
         /**
          * @var Offset $entity
          */
-        $entity = $this->getStackAsEntity();
+        $entity = $this->stackAsRubyClass();
 
         $this->validateType(
             Offset::class,
@@ -315,42 +307,34 @@ trait OperandHelper
         return $entity;
     }
 
-    private function getStackAsID(): ID
+    private function stackAsID(): ID
     {
-        $value = $this->getStackAsAny(ID::class);
+        $value = $this->stackAsAny(ID::class);
 
         assert($value instanceof ID);
 
         return $value;
     }
 
-    private function getStackAsRubyClass(): RubyClassInterface
+    private function stackAsCallInfo(): CallInfoInterface
     {
-        $value = $this->getStackAsAny(RubyClassInterface::class);
-        assert($value instanceof RubyClassInterface);
-
-        return $value;
-    }
-
-    private function getStackAsCallInfo(): CallInfoInterface
-    {
-        $value = $this->getStackAsAny(CallInfoInterface::class);
+        $value = $this->stackAsAny(CallInfoInterface::class);
         assert($value instanceof CallInfoInterface);
 
         return $value;
     }
 
-    private function getStackAsExecutedResult(): ExecutedResult
+    private function stackAsExecutedResult(): ExecutedResult
     {
-        $value = $this->getStackAsAny(ExecutedResult::class);
+        $value = $this->stackAsAny(ExecutedResult::class);
         assert($value instanceof ExecutedResult);
 
         return $value;
     }
 
-    private function getStackAsObject(): RubyClassInterface
+    private function stackAsObject(): RubyClassInterface
     {
-        return $this->getStackAsRubyClass()
+        return $this->stackAsRubyClass()
             ->setRuntimeContext($this->context)
             ->setUserlandHeapSpace($this->context->self()->userlandHeapSpace());
     }
@@ -368,7 +352,7 @@ trait OperandHelper
         return $operand;
     }
 
-    private function getStackAsAny(string $className): CallInfoInterface|RubyClassInterface|ID|ExecutedResult
+    private function stackAsAny(string $className): CallInfoInterface|RubyClassInterface|ID|ExecutedResult
     {
         $operand = $this->getStack();
 

--- a/src/VM/Core/Runtime/Executor/OperatorCalculatable.php
+++ b/src/VM/Core/Runtime/Executor/OperatorCalculatable.php
@@ -18,10 +18,10 @@ trait OperatorCalculatable
 
     private function processArithmetic(string $expectedOperator): ProcessedStatus
     {
-        $recv = $this->getStackAsRubyClass();
-        $obj = $this->getStackAsRubyClass();
+        $recv = $this->stackAsRubyClass();
+        $obj = $this->stackAsRubyClass();
 
-        $callDataOperand = $this->getOperandAsCallInfo();
+        $callDataOperand = $this->operandAsCallInfo();
 
         $operator = $callDataOperand
             ->callData()

--- a/src/VM/Core/Runtime/Kernel/Ruby3_2/Loader/StructSymbolLoader.php
+++ b/src/VM/Core/Runtime/Kernel/Ruby3_2/Loader/StructSymbolLoader.php
@@ -7,6 +7,7 @@ namespace RubyVM\VM\Core\Runtime\Kernel\Ruby3_2\Loader;
 use RubyVM\VM\Core\Runtime\Essential\KernelInterface;
 use RubyVM\VM\Core\YARV\Criterion\Offset\Offset;
 use RubyVM\VM\Core\YARV\Criterion\Structure\Range;
+use RubyVM\VM\Core\YARV\Essential\Symbol\NilSymbol;
 use RubyVM\VM\Core\YARV\Essential\Symbol\NumberSymbol;
 use RubyVM\VM\Core\YARV\Essential\Symbol\RangeSymbol;
 use RubyVM\VM\Core\YARV\Essential\Symbol\SymbolInterface;
@@ -38,11 +39,11 @@ class StructSymbolLoader implements SymbolLoaderInterface
         $endSymbol = $this->kernel
             ->findObject($range->end);
 
-        if (!$beginSymbol instanceof NumberSymbol) {
+        if (!$beginSymbol instanceof NumberSymbol && !$beginSymbol instanceof NilSymbol) {
             throw new RubyVMException(sprintf('The StructSymbolLoader expects NumberSymbol at a begin property when creating a range object but actual symbol is %s', $beginSymbol::class));
         }
 
-        if (!$endSymbol instanceof NumberSymbol) {
+        if (!$endSymbol instanceof NumberSymbol && !$endSymbol instanceof NilSymbol) {
             throw new RubyVMException(sprintf('The StructSymbolLoader expects NumberSymbol at a end property when creating a range object but actual symbol is %s', $endSymbol::class));
         }
 

--- a/src/VM/Core/YARV/Essential/Symbol/FloatSymbol.php
+++ b/src/VM/Core/YARV/Essential/Symbol/FloatSymbol.php
@@ -18,7 +18,7 @@ class FloatSymbol implements SymbolInterface, \Stringable
     public function __toString(): string
     {
         if ($this->number === INF) {
-            return INF . '';
+            return (string) INF;
         }
 
         $hasFraction = str_contains((string) $this->number, '.');

--- a/src/VM/Core/YARV/Essential/Symbol/FloatSymbol.php
+++ b/src/VM/Core/YARV/Essential/Symbol/FloatSymbol.php
@@ -17,6 +17,10 @@ class FloatSymbol implements SymbolInterface, \Stringable
 
     public function __toString(): string
     {
+        if ($this->number === INF) {
+            return INF . '';
+        }
+
         $hasFraction = str_contains((string) $this->number, '.');
         if ($hasFraction) {
             return rtrim(

--- a/src/VM/Core/YARV/Essential/Symbol/RangeSymbol.php
+++ b/src/VM/Core/YARV/Essential/Symbol/RangeSymbol.php
@@ -4,49 +4,34 @@ declare(strict_types=1);
 
 namespace RubyVM\VM\Core\YARV\Essential\Symbol;
 
+use RubyVM\VM\Exception\SymbolUnsupportedException;
+
 /**
  * @implements \ArrayAccess<int, NumberSymbol>
- * @implements \IteratorAggregate<int, SymbolInterface>
+ * @implements \Iterator<int, SymbolInterface>
  */
-class RangeSymbol implements SymbolInterface, \ArrayAccess, \Countable, \IteratorAggregate, \Stringable
+class RangeSymbol implements SymbolInterface, \ArrayAccess, \Countable, \Stringable, \Iterator
 {
-    /**
-     * @var array<int, NumberSymbol>
-     */
-    private array $array;
+    private ?int $pointer = null;
+    private int $pointerKey = 0;
+
+    private int $behindPos = 0;
 
     public function __construct(
-        private readonly NumberSymbol $begin,
-        private readonly NumberSymbol $end,
+        private readonly NumberSymbol|NilSymbol $begin,
+        private readonly NumberSymbol|NilSymbol $end,
         private readonly bool $excludeEnd,
-        private readonly int $steps = 1,
     ) {
-        if ($this->begin->valueOf() > $this->end->valueOf()) {
-            $this->array = [];
-
-            return;
-        }
-
-        $array = [];
-        foreach (range(
-            $this->begin->valueOf(),
-            $this->end->valueOf() - ($this->excludeEnd ? 1 : 0),
-            $this->steps,
-        ) as $i) {
-            $array[] = new NumberSymbol($i);
-        }
-
-        $this->array = $array;
+        $this->pointer = $this->begin->valueOf();
+        $this->behindPos = $this->begin->valueOf();
     }
 
     public function count(): int
     {
-        return count($this->array);
-    }
-
-    public function getIterator(): \Traversable
-    {
-        return new \ArrayIterator($this->array);
+        if ($this->end instanceof NilSymbol) {
+            return PHP_INT_MAX;
+        }
+        return $this->end->valueOf();
     }
 
     /**
@@ -54,31 +39,87 @@ class RangeSymbol implements SymbolInterface, \ArrayAccess, \Countable, \Iterato
      */
     public function valueOf(): array
     {
-        return $this->array;
+        return [];
     }
 
     public function __toString(): string
     {
-        return "{$this->begin->valueOf()}" . ($this->excludeEnd ? '...' : '..') . "{$this->end->valueOf()}";
+        $dots = ($this->excludeEnd ? '...' : '..');
+
+        if ($this->begin instanceof NilSymbol) {
+            return $dots . "{$this->end->valueOf()}";
+        }
+
+        if ($this->end instanceof NilSymbol) {
+            return "{$this->begin->valueOf()}" . $dots;
+        }
+
+        return "{$this->begin->valueOf()}" . $dots . "{$this->end->valueOf()}";
     }
 
     public function offsetExists(mixed $offset): bool
     {
-        return isset($this->array[$offset]);
+        return $this->shouldBeExists((int) $offset - $this->behindPos);
     }
 
     public function offsetGet(mixed $offset): mixed
     {
-        return $this->array[$offset];
+        if ($this->shouldBeExists((int) $offset - $this->behindPos)) {
+            return new NumberSymbol(
+                (int) $offset - $this->behindPos,
+            );
+        }
+        return null;
     }
 
     public function offsetSet(mixed $offset, mixed $value): void
     {
-        $this->array[(int) $offset] = $value;
+        throw new SymbolUnsupportedException('The range symbol cannot appending new value');
     }
 
     public function offsetUnset(mixed $offset): void
     {
-        unset($this->array[$offset]);
+        throw new SymbolUnsupportedException('The range symbol cannot unset a value');
+    }
+
+    private function shouldBeExists(int $value): bool
+    {
+        if (!$this->end instanceof NumberSymbol) {
+            return true;
+        }
+        if (!$this->excludeEnd && $value <= $this->count()) {
+            return true;
+        }
+        if ($this->excludeEnd && $value < $this->count()) {
+            return true;
+        }
+        return false;
+    }
+
+    public function current(): mixed
+    {
+        return new NumberSymbol($this->pointer);
+    }
+
+    public function next(): void
+    {
+        $this->pointer++;
+        $this->pointerKey++;
+    }
+
+    public function key(): mixed
+    {
+        return $this->pointerKey;
+    }
+
+    public function valid(): bool
+    {
+        return $this->shouldBeExists($this->pointer);
+    }
+
+    public function rewind(): void
+    {
+        $this->pointer = $this->begin->valueOf();
+        $this->pointerKey = 0;
     }
 }

--- a/tests/Internal/DebugFormatTest.php
+++ b/tests/Internal/DebugFormatTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\Internal;
+namespace Tests\RubyVM\Version\RubyVM\Internal;
 
 use RubyVM\VM\Core\Criterion\Entry\AbstractEntries;
 use RubyVM\VM\Core\Runtime\BasicObject\Kernel\Object_\Comparable\Integer_;

--- a/tests/Version/RubyVM/Call/BasicObject/Kernel/Object_/Comparable/IntegerTest.php
+++ b/tests/Version/RubyVM/Call/BasicObject/Kernel/Object_/Comparable/IntegerTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\RubyVM\Version\RubyVM\Call\BasicObject\Kernel\Object_\Enumerable;
+
+use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
+use RubyVM\VM\Core\YARV\RubyVersion;
+use Tests\RubyVM\Helper\TestApplication;
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
+class IntegerTest extends TestApplication
+{
+    public function testEven(): void
+    {
+        $rubyVMManager = $this->createRubyVMFromCode(
+            <<< '_'
+            puts 3.even?
+            puts 2.even?
+            _,
+        );
+
+        $executor = $rubyVMManager
+            ->rubyVM
+            ->disassemble(RubyVersion::VERSION_3_2);
+
+        $this->assertSame(ExecutedStatus::SUCCESS, $executor->execute()->executedStatus);
+        $this->assertSame(<<<'_'
+        false
+        true
+
+        _, $rubyVMManager->stdOut->readAll());
+    }
+
+    public function testOdd(): void
+    {
+        $rubyVMManager = $this->createRubyVMFromCode(
+            <<< '_'
+            puts 3.odd?
+            puts 2.odd?
+            _,
+        );
+
+        $executor = $rubyVMManager
+            ->rubyVM
+            ->disassemble(RubyVersion::VERSION_3_2);
+
+        $this->assertSame(ExecutedStatus::SUCCESS, $executor->execute()->executedStatus);
+        $this->assertSame(<<<'_'
+        true
+        false
+
+        _, $rubyVMManager->stdOut->readAll());
+    }
+
+    public function testZero(): void
+    {
+        $rubyVMManager = $this->createRubyVMFromCode(
+            <<< '_'
+            puts 1.zero?
+            puts 0.zero?
+            _,
+        );
+
+        $executor = $rubyVMManager
+            ->rubyVM
+            ->disassemble(RubyVersion::VERSION_3_2);
+
+        $this->assertSame(ExecutedStatus::SUCCESS, $executor->execute()->executedStatus);
+        $this->assertSame(<<<'_'
+        false
+        true
+
+        _, $rubyVMManager->stdOut->readAll());
+    }
+}

--- a/tests/Version/RubyVM/Call/BasicObject/Kernel/Object_/Comparable/StringTest.php
+++ b/tests/Version/RubyVM/Call/BasicObject/Kernel/Object_/Comparable/StringTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\RubyVM\Version\RubyVM\Call\BasicObject\Kernel\Object_\Enumerable;
+
+use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
+use RubyVM\VM\Core\YARV\RubyVersion;
+use Tests\RubyVM\Helper\TestApplication;
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
+class StringTest extends TestApplication
+{
+    public function testEven(): void
+    {
+        $rubyVMManager = $this->createRubyVMFromCode(
+            <<< '_'
+            puts "".empty?
+            puts "Hello World!".empty?
+            _,
+        );
+
+        $executor = $rubyVMManager
+            ->rubyVM
+            ->disassemble(RubyVersion::VERSION_3_2);
+
+        $this->assertSame(ExecutedStatus::SUCCESS, $executor->execute()->executedStatus);
+        $this->assertSame(<<<'_'
+        true
+        false
+
+        _, $rubyVMManager->stdOut->readAll());
+    }
+}

--- a/tests/Version/RubyVM/Call/BasicObject/Kernel/Object_/Comparable/StringTest.php
+++ b/tests/Version/RubyVM/Call/BasicObject/Kernel/Object_/Comparable/StringTest.php
@@ -35,6 +35,7 @@ class StringTest extends TestApplication
 
         _, $rubyVMManager->stdOut->readAll());
     }
+
     public function testInclude(): void
     {
         $rubyVMManager = $this->createRubyVMFromCode(

--- a/tests/Version/RubyVM/Call/BasicObject/Kernel/Object_/Comparable/StringTest.php
+++ b/tests/Version/RubyVM/Call/BasicObject/Kernel/Object_/Comparable/StringTest.php
@@ -15,12 +15,32 @@ use Tests\RubyVM\Helper\TestApplication;
  */
 class StringTest extends TestApplication
 {
-    public function testEven(): void
+    public function testEmpty(): void
     {
         $rubyVMManager = $this->createRubyVMFromCode(
             <<< '_'
             puts "".empty?
             puts "Hello World!".empty?
+            _,
+        );
+
+        $executor = $rubyVMManager
+            ->rubyVM
+            ->disassemble(RubyVersion::VERSION_3_2);
+
+        $this->assertSame(ExecutedStatus::SUCCESS, $executor->execute()->executedStatus);
+        $this->assertSame(<<<'_'
+        true
+        false
+
+        _, $rubyVMManager->stdOut->readAll());
+    }
+    public function testInclude(): void
+    {
+        $rubyVMManager = $this->createRubyVMFromCode(
+            <<< '_'
+            puts "Hello World!".include? "World"
+            puts "Hello World!".include? "Underground"
             _,
         );
 

--- a/tests/Version/RubyVM/Call/BasicObject/Kernel/Object_/Enumerable/ArrayTest.php
+++ b/tests/Version/RubyVM/Call/BasicObject/Kernel/Object_/Enumerable/ArrayTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\Call\BasicObject\Kernel\Object_\Enumerable;
+namespace Tests\RubyVM\Version\RubyVM\Call\BasicObject\Kernel\Object_\Enumerable;
 
 use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
 use RubyVM\VM\Core\YARV\RubyVersion;

--- a/tests/Version/RubyVM/Call/BasicObject/Kernel/Object_/Enumerable/RangeTest.php
+++ b/tests/Version/RubyVM/Call/BasicObject/Kernel/Object_/Enumerable/RangeTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\Call\BasicObject\Kernel\Object_\Enumerable;
+namespace Tests\RubyVM\Version\RubyVM\Call\BasicObject\Kernel\Object_\Enumerable;
 
 use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
 use RubyVM\VM\Core\YARV\RubyVersion;

--- a/tests/Version/RubyVM/Call/BasicObject/Kernel/Object_/Enumerable/RangeTest.php
+++ b/tests/Version/RubyVM/Call/BasicObject/Kernel/Object_/Enumerable/RangeTest.php
@@ -47,4 +47,23 @@ class RangeTest extends TestApplication
 
         _, $rubyVMManager->stdOut->readAll());
     }
+
+    public function testInfinityRange(): void
+    {
+        $rubyVMManager = $this->createRubyVMFromCode(
+            <<< '_'
+            puts 1.. === Float::INFINITY
+            _,
+        );
+
+        $executor = $rubyVMManager
+            ->rubyVM
+            ->disassemble(RubyVersion::VERSION_3_2);
+
+        $this->assertSame(ExecutedStatus::SUCCESS, $executor->execute()->executedStatus);
+        $this->assertSame(<<<'_'
+        true
+
+        _, $rubyVMManager->stdOut->readAll());
+    }
 }

--- a/tests/Version/RubyVM/Call/Logic/Complex/FibonacciTest.php
+++ b/tests/Version/RubyVM/Call/Logic/Complex/FibonacciTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\Call\Complex;
+namespace Tests\RubyVM\Version\RubyVM\Call\Complex;
 
 use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
 use RubyVM\VM\Core\YARV\RubyVersion;

--- a/tests/Version/RubyVM/Call/Logic/Complex/FizzBuzzTest.php
+++ b/tests/Version/RubyVM/Call/Logic/Complex/FizzBuzzTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\Call\Complex;
+namespace Tests\RubyVM\Version\RubyVM\Call\Complex;
 
 use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
 use RubyVM\VM\Core\YARV\RubyVersion;

--- a/tests/Version/RubyVM/Call/Logic/Complex/QuicksortTest.php
+++ b/tests/Version/RubyVM/Call/Logic/Complex/QuicksortTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\Call\Complex;
+namespace Tests\RubyVM\Version\RubyVM\Call\Complex;
 
 use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
 use RubyVM\VM\Core\YARV\RubyVersion;

--- a/tests/Version/RubyVM/Call/Method/InspectionTest.php
+++ b/tests/Version/RubyVM/Call/Method/InspectionTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\Call\Method;
+namespace Tests\RubyVM\Version\RubyVM\Call\Method;
 
 use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
 use RubyVM\VM\Core\YARV\RubyVersion;

--- a/tests/Version/RubyVM/Call/Method/LambdaTest.php
+++ b/tests/Version/RubyVM/Call/Method/LambdaTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\Call\Method;
+namespace Tests\RubyVM\Version\RubyVM\Call\Method;
 
 use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
 use RubyVM\VM\Core\YARV\RubyVersion;

--- a/tests/Version/RubyVM/Call/Method/MethodTest.php
+++ b/tests/Version/RubyVM/Call/Method/MethodTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\Call\Method;
+namespace Tests\RubyVM\Version\RubyVM\Call\Method;
 
 use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
 use RubyVM\VM\Core\YARV\RubyVersion;

--- a/tests/Version/RubyVM/Call/Method/NilTest.php
+++ b/tests/Version/RubyVM/Call/Method/NilTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\RubyVM\GenericSyntax;
+namespace Tests\RubyVM\Version\RubyVM\Call\Method;
 
 use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
 use RubyVM\VM\Core\YARV\RubyVersion;
@@ -13,18 +13,19 @@ use Tests\RubyVM\Helper\TestApplication;
  *
  * @coversNothing
  */
-class HashTest extends TestApplication
+class NilTest extends TestApplication
 {
-    public function testHash(): void
+    public function testObjectIsNil()
     {
         $rubyVMManager = $this->createRubyVMFromCode(
             <<< '_'
-            obj = { a: :symbol, b: 1234, c: 'Hello World!' }
+            var1 = nil
+            var2 = "text"
 
-            puts obj[:a]
-            puts obj[:b]
-            puts obj[:c]
-
+            puts nil.nil?
+            puts var1.nil?
+            puts var2.nil?
+            puts 1.nil?
             _,
         );
 
@@ -33,10 +34,11 @@ class HashTest extends TestApplication
             ->disassemble(RubyVersion::VERSION_3_2);
 
         $this->assertSame(ExecutedStatus::SUCCESS, $executor->execute()->executedStatus);
-        $this->assertSame(<<<'_'
-        symbol
-        1234
-        Hello World!
+        $this->assertSame(<<<_
+        true
+        true
+        false
+        false
 
         _, $rubyVMManager->stdOut->readAll());
     }

--- a/tests/Version/RubyVM/Call/Method/NilTest.php
+++ b/tests/Version/RubyVM/Call/Method/NilTest.php
@@ -15,7 +15,7 @@ use Tests\RubyVM\Helper\TestApplication;
  */
 class NilTest extends TestApplication
 {
-    public function testObjectIsNil()
+    public function testObjectIsNil(): void
     {
         $rubyVMManager = $this->createRubyVMFromCode(
             <<< '_'
@@ -34,7 +34,7 @@ class NilTest extends TestApplication
             ->disassemble(RubyVersion::VERSION_3_2);
 
         $this->assertSame(ExecutedStatus::SUCCESS, $executor->execute()->executedStatus);
-        $this->assertSame(<<<_
+        $this->assertSame(<<<'_'
         true
         true
         false

--- a/tests/Version/RubyVM/Call/Method/ToIntTest.php
+++ b/tests/Version/RubyVM/Call/Method/ToIntTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\Call\Method;
+namespace Tests\RubyVM\Version\RubyVM\Call\Method;
 
 use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
 use RubyVM\VM\Core\YARV\RubyVersion;

--- a/tests/Version/RubyVM/Call/Method/ToStringTest.php
+++ b/tests/Version/RubyVM/Call/Method/ToStringTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\Call\Method;
+namespace Tests\RubyVM\Version\RubyVM\Call\Method;
 
 use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
 use RubyVM\VM\Core\YARV\RubyVersion;

--- a/tests/Version/RubyVM/Call/PHP/CallRubyMethodsTest.php
+++ b/tests/Version/RubyVM/Call/PHP/CallRubyMethodsTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\Call\PHP;
+namespace Tests\RubyVM\Version\RubyVM\Call\PHP;
 
 use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
 use RubyVM\VM\Core\YARV\RubyVersion;

--- a/tests/Version/RubyVM/GenericSyntax/ArithmeticTest.php
+++ b/tests/Version/RubyVM/GenericSyntax/ArithmeticTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\GenericSyntax;
+namespace Tests\RubyVM\Version\RubyVM\GenericSyntax;
 
 use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
 use RubyVM\VM\Core\YARV\RubyVersion;

--- a/tests/Version/RubyVM/GenericSyntax/BooleanTest.php
+++ b/tests/Version/RubyVM/GenericSyntax/BooleanTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\GenericSyntax;
+namespace Tests\RubyVM\Version\RubyVM\GenericSyntax;
 
 use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
 use RubyVM\VM\Core\YARV\RubyVersion;

--- a/tests/Version/RubyVM/GenericSyntax/CaseWhenTest.php
+++ b/tests/Version/RubyVM/GenericSyntax/CaseWhenTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\GenericSyntax;
+namespace Tests\RubyVM\Version\RubyVM\GenericSyntax;
 
 use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
 use RubyVM\VM\Core\YARV\RubyVersion;

--- a/tests/Version/RubyVM/GenericSyntax/Class/DefineClassTest.php
+++ b/tests/Version/RubyVM/GenericSyntax/Class/DefineClassTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\GenericSyntax\Class;
+namespace Tests\RubyVM\Version\RubyVM\GenericSyntax\Class;
 
 use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
 use RubyVM\VM\Core\YARV\RubyVersion;

--- a/tests/Version/RubyVM/GenericSyntax/Class/DefineMethodInClassTest.php
+++ b/tests/Version/RubyVM/GenericSyntax/Class/DefineMethodInClassTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\GenericSyntax\Class;
+namespace Tests\RubyVM\Version\RubyVM\GenericSyntax\Class;
 
 use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
 use RubyVM\VM\Core\YARV\RubyVersion;

--- a/tests/Version/RubyVM/GenericSyntax/Class/DefineStaticMethodTest.php
+++ b/tests/Version/RubyVM/GenericSyntax/Class/DefineStaticMethodTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\GenericSyntax\Class;
+namespace Tests\RubyVM\Version\RubyVM\GenericSyntax\Class;
 
 use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
 use RubyVM\VM\Core\YARV\RubyVersion;

--- a/tests/Version/RubyVM/GenericSyntax/Class/ExtendedClassTest.php
+++ b/tests/Version/RubyVM/GenericSyntax/Class/ExtendedClassTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\GenericSyntax\Class;
+namespace Tests\RubyVM\Version\RubyVM\GenericSyntax\Class;
 
 use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
 use RubyVM\VM\Core\YARV\RubyVersion;

--- a/tests/Version/RubyVM/GenericSyntax/Class/InstanceVariableTest.php
+++ b/tests/Version/RubyVM/GenericSyntax/Class/InstanceVariableTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\GenericSyntax\Class;
+namespace Tests\RubyVM\Version\RubyVM\GenericSyntax\Class;
 
 use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
 use RubyVM\VM\Core\YARV\RubyVersion;

--- a/tests/Version/RubyVM/GenericSyntax/ComparableTest.php
+++ b/tests/Version/RubyVM/GenericSyntax/ComparableTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\GenericSyntax;
+namespace Tests\RubyVM\Version\RubyVM\GenericSyntax;
 
 use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
 use RubyVM\VM\Core\YARV\RubyVersion;

--- a/tests/Version/RubyVM/GenericSyntax/ConcatTest.php
+++ b/tests/Version/RubyVM/GenericSyntax/ConcatTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\GenericSyntax;
+namespace Tests\RubyVM\Version\RubyVM\GenericSyntax;
 
 use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
 use RubyVM\VM\Core\YARV\RubyVersion;

--- a/tests/Version/RubyVM/GenericSyntax/GlobalVariableTest.php
+++ b/tests/Version/RubyVM/GenericSyntax/GlobalVariableTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\GenericSyntax;
+namespace Tests\RubyVM\Version\RubyVM\GenericSyntax;
 
 use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
 use RubyVM\VM\Core\YARV\RubyVersion;

--- a/tests/Version/RubyVM/GenericSyntax/KeywordArgumentsTest.php
+++ b/tests/Version/RubyVM/GenericSyntax/KeywordArgumentsTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\GenericSyntax;
+namespace Tests\RubyVM\Version\RubyVM\GenericSyntax;
 
 use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
 use RubyVM\VM\Core\YARV\RubyVersion;

--- a/tests/Version/RubyVM/GenericSyntax/LocalVariableTest.php
+++ b/tests/Version/RubyVM/GenericSyntax/LocalVariableTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\GenericSyntax;
+namespace Tests\RubyVM\Version\RubyVM\GenericSyntax;
 
 use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
 use RubyVM\VM\Core\YARV\RubyVersion;

--- a/tests/Version/RubyVM/GenericSyntax/Method/BlockTest.php
+++ b/tests/Version/RubyVM/GenericSyntax/Method/BlockTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\GenericSyntax\Method;
+namespace Tests\RubyVM\Version\RubyVM\GenericSyntax\Method;
 
 use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
 use RubyVM\VM\Core\YARV\RubyVersion;

--- a/tests/Version/RubyVM/GenericSyntax/Method/DefineMethodTest.php
+++ b/tests/Version/RubyVM/GenericSyntax/Method/DefineMethodTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\GenericSyntax\Method;
+namespace Tests\RubyVM\Version\RubyVM\GenericSyntax\Method;
 
 use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
 use RubyVM\VM\Core\YARV\RubyVersion;

--- a/tests/Version/RubyVM/GenericSyntax/NegativeValueTest.php
+++ b/tests/Version/RubyVM/GenericSyntax/NegativeValueTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\GenericSyntax;
+namespace Tests\RubyVM\Version\RubyVM\GenericSyntax;
 
 use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
 use RubyVM\VM\Core\YARV\RubyVersion;

--- a/tests/Version/RubyVM/GenericSyntax/RaiseTest.php
+++ b/tests/Version/RubyVM/GenericSyntax/RaiseTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\GenericSyntax;
+namespace Tests\RubyVM\Version\RubyVM\GenericSyntax;
 
 use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
 use RubyVM\VM\Core\YARV\RubyVersion;

--- a/tests/Version/RubyVM/GenericSyntax/RegexpTest.php
+++ b/tests/Version/RubyVM/GenericSyntax/RegexpTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\GenericSyntax;
+namespace Tests\RubyVM\Version\RubyVM\GenericSyntax;
 
 use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
 use RubyVM\VM\Core\YARV\RubyVersion;

--- a/tests/Version/RubyVM/GenericSyntax/RescueTest.php
+++ b/tests/Version/RubyVM/GenericSyntax/RescueTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\GenericSyntax;
+namespace Tests\RubyVM\Version\RubyVM\GenericSyntax;
 
 use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
 use RubyVM\VM\Core\YARV\RubyVersion;

--- a/tests/Version/RubyVM/GenericSyntax/SymbolTest.php
+++ b/tests/Version/RubyVM/GenericSyntax/SymbolTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\GenericSyntax;
+namespace Tests\RubyVM\Version\RubyVM\GenericSyntax;
 
 use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
 use RubyVM\VM\Core\YARV\RubyVersion;

--- a/tests/Version/RubyVM/GenericSyntax/VariadicTest.php
+++ b/tests/Version/RubyVM/GenericSyntax/VariadicTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\GenericSyntax;
+namespace Tests\RubyVM\Version\RubyVM\GenericSyntax;
 
 use RubyVM\VM\Core\Runtime\Executor\ExecutedStatus;
 use RubyVM\VM\Core\YARV\RubyVersion;

--- a/tests/Version/RubyVM/YARB/YARBStructureTest.php
+++ b/tests/Version/RubyVM/YARB/YARBStructureTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\RubyVM\Version\Ruby3_2\YARB;
+namespace Tests\RubyVM\Version\RubyVM\YARB;
 
 use Tests\RubyVM\Helper\TestApplication;
 


### PR DESCRIPTION
supports

```ruby
var1 = nil
var2 = "text"

puts nil.nil?
puts var1.nil?
puts var2.nil?
puts 1.nil?
```

supports

```ruby
puts "".empty?
puts 3.even?
puts 3.odd?
puts 1.zero?
puts 0.zero?
```

supports

```ruby
puts 1.. === Float::INFINITY

# supported infinity loop, but here is the future getting stack overflow
(1..).each do | v |
  puts v
end

```