### PR TITLE
Implement concatarray opcode

### DIFF
--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinConcatarray.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinConcatarray.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace RubyVM\VM\Core\Runtime\Executor\Insn\Processor;
 
+use RubyVM\VM\Core\Runtime\BasicObject\Kernel\Object_\Enumerable\Array_;
 use RubyVM\VM\Core\Runtime\Essential\RubyClassInterface;
 use RubyVM\VM\Core\Runtime\Executor\Context\ContextInterface;
 use RubyVM\VM\Core\Runtime\Executor\Insn\Insn;
+use RubyVM\VM\Core\Runtime\Executor\Operation\Operand;
 use RubyVM\VM\Core\Runtime\Executor\Operation\OperandHelper;
 use RubyVM\VM\Core\Runtime\Executor\Operation\Processor\OperationProcessorInterface;
 use RubyVM\VM\Core\Runtime\Executor\ProcessedStatus;
-use RubyVM\VM\Exception\OperationProcessorException;
 
 class BuiltinConcatarray implements OperationProcessorInterface
 {
@@ -31,6 +32,23 @@ class BuiltinConcatarray implements OperationProcessorInterface
 
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
-        throw new OperationProcessorException(sprintf('The `%s` (opcode: 0x%02x) processor is not implemented yet', strtolower($this->insn->name), $this->insn->value));
+        $array2 = $this->stackAsRubyClass();
+        $array1 = $this->stackAsRubyClass();
+
+        assert($array1 instanceof Array_);
+        assert($array2 instanceof Array_);
+
+        $this->context->vmStack()->push(
+            new Operand(
+                Array_::createBy(
+                    [
+                        ...$array1->valueOf(),
+                        ...$array2->valueOf(),
+                    ],
+                ),
+            ),
+        );
+
+        return ProcessedStatus::SUCCESS;
     }
 }

--- a/tests/Version/RubyVM/GenericSyntax/ConcatTest.php
+++ b/tests/Version/RubyVM/GenericSyntax/ConcatTest.php
@@ -46,4 +46,21 @@ class ConcatTest extends TestApplication
         $this->assertSame(ExecutedStatus::SUCCESS, $executor->execute()->executedStatus);
         $this->assertSame("HelloWorld65535\n", $rubyVMManager->stdOut->readAll());
     }
+
+    public function testConcatArray(): void
+    {
+        $rubyVMManager = $this->createRubyVMFromCode(
+            <<< '_'
+            v = [4, 5, 6]
+            puts [*[1, 2, 3], *v].inspect
+            _,
+        );
+
+        $executor = $rubyVMManager
+            ->rubyVM
+            ->disassemble(RubyVersion::VERSION_3_2);
+
+        $this->assertSame(ExecutedStatus::SUCCESS, $executor->execute()->executedStatus);
+        $this->assertSame("[1, 2, 3, 4, 5, 6]\n", $rubyVMManager->stdOut->readAll());
+    }
 }


### PR DESCRIPTION
supports:


```ruby
v = [4, 5, 6]
puts [*[1, 2, 3], *v].inspect
```