### PR TITLE
Implement splatarray opcode

### DIFF
--- a/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinSplatarray.php
+++ b/src/VM/Core/Runtime/Executor/Insn/Processor/BuiltinSplatarray.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace RubyVM\VM\Core\Runtime\Executor\Insn\Processor;
 
+use RubyVM\VM\Core\Runtime\BasicObject\Kernel\Object_\Enumerable\Array_;
 use RubyVM\VM\Core\Runtime\Essential\RubyClassInterface;
 use RubyVM\VM\Core\Runtime\Executor\Context\ContextInterface;
 use RubyVM\VM\Core\Runtime\Executor\Insn\Insn;
+use RubyVM\VM\Core\Runtime\Executor\Operation\Operand;
 use RubyVM\VM\Core\Runtime\Executor\Operation\OperandHelper;
 use RubyVM\VM\Core\Runtime\Executor\Operation\Processor\OperationProcessorInterface;
 use RubyVM\VM\Core\Runtime\Executor\ProcessedStatus;
-use RubyVM\VM\Exception\OperationProcessorException;
 
 class BuiltinSplatarray implements OperationProcessorInterface
 {
@@ -31,6 +32,24 @@ class BuiltinSplatarray implements OperationProcessorInterface
 
     public function process(ContextInterface|RubyClassInterface ...$arguments): ProcessedStatus
     {
-        throw new OperationProcessorException(sprintf('The `%s` (opcode: 0x%02x) processor is not implemented yet', strtolower($this->insn->name), $this->insn->value));
+        $flag = $this->operandAsRubyClass();
+
+        $array = $this->stackAsRubyClass();
+
+        if ($array instanceof Array_) {
+            $this->context->vmStack()->push(
+                new Operand(
+                    Array_::createBy($array->valueOf()),
+                ),
+            );
+        } else {
+            $this->context->vmStack()->push(
+                new Operand(
+                    Array_::createBy([$array->valueOf()]),
+                ),
+            );
+        }
+
+        return ProcessedStatus::SUCCESS;
     }
 }

--- a/tests/Version/RubyVM/GenericSyntax/ConcatTest.php
+++ b/tests/Version/RubyVM/GenericSyntax/ConcatTest.php
@@ -85,6 +85,7 @@ class ConcatTest extends TestApplication
         $this->assertSame(<<<'_'
         [1, 4, 5, 6]
         [1, 2, 3, 4, 5, 6]
+        
         _, $rubyVMManager->stdOut->readAll());
     }
 }

--- a/tests/Version/RubyVM/GenericSyntax/ConcatTest.php
+++ b/tests/Version/RubyVM/GenericSyntax/ConcatTest.php
@@ -63,4 +63,28 @@ class ConcatTest extends TestApplication
         $this->assertSame(ExecutedStatus::SUCCESS, $executor->execute()->executedStatus);
         $this->assertSame("[1, 2, 3, 4, 5, 6]\n", $rubyVMManager->stdOut->readAll());
     }
+
+    public function testSplatArrayInMethod(): void
+    {
+        $rubyVMManager = $this->createRubyVMFromCode(
+            <<< '_'
+            def arr(args)
+              puts [*args, *[4, 5, 6]].inspect
+            end
+
+            arr 1
+            arr [1, 2, 3]
+            _,
+        );
+
+        $executor = $rubyVMManager
+            ->rubyVM
+            ->disassemble(RubyVersion::VERSION_3_2);
+
+        $this->assertSame(ExecutedStatus::SUCCESS, $executor->execute()->executedStatus);
+        $this->assertSame(<<<'_'
+        [1, 4, 5, 6]
+        [1, 2, 3, 4, 5, 6]
+        _, $rubyVMManager->stdOut->readAll());
+    }
 }


### PR DESCRIPTION
supports:

```ruby
def arr(args)
  puts [*args, *[4, 5, 6]].inspect
end

arr 1
arr [1, 2, 3]
```